### PR TITLE
feat: Add sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea), [Lip Gloss]
 
 - **Browse all packages** — lists every available APT package with version and size info loaded lazily
 - **Fuzzy search** — live fuzzy filtering as you type, with fallback to `apt-cache search`
+- **Advanced filter** — powerful query language to filter by section, architecture, size, status and more ([docs](docs/filter.md))
+- **Column sorting** — sort packages by name, version, size, section or architecture (ascending/descending)
 - **Tabs** — switch between *All*, *Installed* and *Upgradable* views
 - **Multi-select** — mark multiple packages with `space`, then bulk install/remove/upgrade
 - **Parallel downloads** — installs and upgrades use parallel downloads by default for faster operations
@@ -71,14 +73,25 @@ aptui
 | `pgdown` / `ctrl+d` | Page down |
 | `tab` | Switch tab (All → Installed → Upgradable) |
 
-### Search
+### Search & Filter
 
 | Key | Action |
 |---|---|
 | `/` | Open search bar |
-| `F` | Open filter bar |
-| `enter` | Confirm search |
-| `esc` | Clear search / go back |
+| `F` | Open [advanced filter](docs/filter.md) bar |
+| `enter` | Confirm search / apply filter |
+| `esc` | Clear search / filter / go back |
+
+#### Filter examples
+
+```
+installed size>10MB          # installed packages larger than 10 MB
+section:utils order:name     # packages in "utils" section, sorted A→Z
+order:size:desc              # all packages sorted by size, largest first
+order:size:asc               # all packages sorted by size, smallest first
+```
+
+See the full [filter documentation](docs/filter.md) for all available options.
 
 ### Selection
 

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -151,6 +151,63 @@ name:python sec:python arch:amd64 installed
 
 ---
 
+## Sorting (order)
+
+You can sort the results by a column using the `order:` syntax:
+
+```
+order:<column>           → sort ascending (default)
+order:<column>:asc       → sort ascending (explicit)
+order:<column>:desc      → sort descending
+```
+
+### Available columns
+
+| Column          | Aliases | Description                        |
+|-----------------|---------|------------------------------------|
+| `name`          | —       | Sort by package name               |
+| `version`       | `ver`   | Sort by version string             |
+| `size`          | —       | Sort by installed size             |
+| `section`       | `sec`   | Sort by section                    |
+| `architecture`  | `arch`  | Sort by architecture               |
+
+**Examples:**
+
+```
+order:name               → sort by name A→Z
+order:name:desc          → sort by name Z→A
+order:size:desc          → largest packages first
+order:size:asc           → smallest packages first
+order:ver:desc           → newest versions first
+```
+
+### Combining sort with filters
+
+Sort can be combined with any other filter:
+
+```
+installed order:size:desc
+```
+→ Installed packages, largest first
+
+```
+section:utils order:name
+```
+→ Packages in "utils" section, sorted by name A→Z
+
+```
+!installed size>10MB order:size:desc
+```
+→ Not-installed packages larger than 10 MB, largest first
+
+> **Note:** When a sort is active, the column header in the package list shows ▲ (ascending) or ▼ (descending).
+
+### Unknown data handling
+
+Packages whose metadata hasn't been loaded yet (showing "-" for version or size) are always pushed to the **end** of the sorted list, regardless of sort direction. This ensures that packages with real data are always visible first.
+
+---
+
 ## Combining filter with search
 
 The advanced filter (`Shift+F`) works **together** with text search (`/`). You can:

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -94,8 +94,63 @@ func (a *App) applyFilter() {
 			a.filtered[i] = sp.pkg
 		}
 	}
+
+	// Apply sorting if order is specified in the filter
+	if af.OrderBy != filter.SortNone {
+		sort.SliceStable(a.filtered, func(i, j int) bool {
+			pi, pj := a.filtered[i], a.filtered[j]
+
+			// Push packages with unknown data to the end
+			iEmpty, jEmpty := sortFieldEmpty(pi, af.OrderBy), sortFieldEmpty(pj, af.OrderBy)
+			if iEmpty != jEmpty {
+				return !iEmpty // non-empty comes first
+			}
+			if iEmpty && jEmpty {
+				return false // both empty, keep original order
+			}
+
+			var less bool
+			switch af.OrderBy {
+			case filter.SortName:
+				less = strings.ToLower(pi.Name) < strings.ToLower(pj.Name)
+			case filter.SortVersion:
+				less = pi.Version < pj.Version
+			case filter.SortSize:
+				less = filter.ParseSizeToKB(pi.Size) < filter.ParseSizeToKB(pj.Size)
+			case filter.SortSection:
+				less = strings.ToLower(pi.Section) < strings.ToLower(pj.Section)
+			case filter.SortArchitecture:
+				less = strings.ToLower(pi.Architecture) < strings.ToLower(pj.Architecture)
+			default:
+				return false
+			}
+			if af.OrderDesc {
+				return !less
+			}
+			return less
+		})
+	}
+
 	a.selectedIdx = 0
 	a.scrollOffset = 0
+}
+
+// sortFieldEmpty returns true if the sort field for the given package is empty/unknown.
+func sortFieldEmpty(p model.Package, col filter.SortColumn) bool {
+	switch col {
+	case filter.SortName:
+		return p.Name == ""
+	case filter.SortVersion:
+		return p.Version == "" && p.NewVersion == ""
+	case filter.SortSize:
+		return p.Size == "" || p.Size == "-"
+	case filter.SortSection:
+		return p.Section == ""
+	case filter.SortArchitecture:
+		return p.Architecture == ""
+	default:
+		return false
+	}
 }
 
 // loadFilterCandidateInfo fetches metadata only for packages that pass all

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -37,7 +37,9 @@ func (a App) View() string {
 		centered := lipgloss.NewStyle().Width(w).Align(lipgloss.Center).Render(loadingLine)
 		listView = strings.Repeat("\n", pad) + centered + strings.Repeat("\n", h-pad)
 	} else {
-		listView = components.RenderPackageList(a.filtered, a.selectedIdx, a.scrollOffset, a.packageListHeight(), w, a.selected)
+		af := filter.Parse(a.advancedFilter)
+		si := filter.SortInfo{Column: af.OrderBy, Desc: af.OrderDesc}
+		listView = components.RenderPackageList(a.filtered, a.selectedIdx, a.scrollOffset, a.packageListHeight(), w, a.selected, si)
 	}
 	listView = tabBar + "\n" + listView
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -18,9 +18,28 @@
 package filter
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
+)
+
+// SortColumn represents which column to sort by.
+type SortColumn int
+
+// SortInfo holds the current sorting state for display purposes.
+type SortInfo struct {
+	Column SortColumn
+	Desc   bool
+}
+
+const (
+	SortNone SortColumn = iota
+	SortName
+	SortVersion
+	SortSize
+	SortSection
+	SortArchitecture
 )
 
 // SizeOp represents a comparison operator for size filters.
@@ -47,9 +66,11 @@ type Filter struct {
 	Size         *SizeFilter
 	Installed    *bool
 	Upgradable   *bool
-	Name         string // contains (case-insensitive)
-	Version      string // contains (case-insensitive)
-	Description  string // contains (case-insensitive)
+	Name         string     // contains (case-insensitive)
+	Version      string     // contains (case-insensitive)
+	Description  string     // contains (case-insensitive)
+	OrderBy      SortColumn // column to sort by
+	OrderDesc    bool       // true for descending order
 }
 
 // IsEmpty returns true if no filter criteria are set.
@@ -61,7 +82,8 @@ func (f Filter) IsEmpty() bool {
 		f.Upgradable == nil &&
 		f.Name == "" &&
 		f.Version == "" &&
-		f.Description == ""
+		f.Description == "" &&
+		f.OrderBy == SortNone
 }
 
 // NeedsMetadata returns true if the filter uses fields (Section, Architecture, Size)
@@ -208,6 +230,19 @@ func Parse(query string) Filter {
 			}
 		}
 
+		// Sorting: order:column or order:column:desc
+		if strings.HasPrefix(lower, "order:") {
+			orderExpr := tok[6:]
+			parts := strings.SplitN(orderExpr, ":", 2)
+			if len(parts) >= 1 {
+				f.OrderBy = parseSortColumn(parts[0])
+				if len(parts) == 2 {
+					f.OrderDesc = strings.EqualFold(parts[1], "desc")
+				}
+			}
+			continue
+		}
+
 		// key:value filters
 		if idx := strings.Index(tok, ":"); idx > 0 {
 			key := strings.ToLower(tok[:idx])
@@ -281,12 +316,19 @@ func (f Filter) Describe() string {
 		}
 		parts = append(parts, "size"+opStr+formatKB(f.Size.KB))
 	}
+	if f.OrderBy != SortNone {
+		dir := "asc"
+		if f.OrderDesc {
+			dir = "desc"
+		}
+		parts = append(parts, "order:"+sortColumnName(f.OrderBy)+":"+dir)
+	}
 	return strings.Join(parts, " ")
 }
 
 // HelpText returns the syntax help shown in the filter bar.
 func HelpText() string {
-	return "section: arch: size>|<|= name: ver: desc: installed !installed upgradable"
+	return "section: arch: size>|<|= name: ver: desc: installed !installed upgradable order:column:asc|desc"
 }
 
 // parseSizeExpr parses a size expression like ">10MB", ">=100kB", "<5GB", "=500kB".
@@ -418,4 +460,103 @@ func tokenize(s string) []string {
 
 func containsFold(s, substr string) bool {
 	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+func parseSortColumn(s string) SortColumn {
+	switch strings.ToLower(s) {
+	case "name":
+		return SortName
+	case "version", "ver":
+		return SortVersion
+	case "size":
+		return SortSize
+	case "section", "sec":
+		return SortSection
+	case "arch", "architecture":
+		return SortArchitecture
+	default:
+		return SortNone
+	}
+}
+
+func sortColumnName(c SortColumn) string {
+	switch c {
+	case SortName:
+		return "name"
+	case SortVersion:
+		return "version"
+	case SortSize:
+		return "size"
+	case SortSection:
+		return "section"
+	case SortArchitecture:
+		return "architecture"
+	default:
+		return ""
+	}
+}
+
+// SortColumnLabel returns a human-friendly label for a SortColumn.
+func SortColumnLabel(c SortColumn) string {
+	return sortColumnName(c)
+}
+
+// Sort sorts a slice of PackageData in place according to the filter's OrderBy and OrderDesc.
+// Packages with unknown/empty values for the sort field are pushed to the end.
+func Sort(pkgs []PackageData, f Filter) {
+	if f.OrderBy == SortNone {
+		return
+	}
+	sort.SliceStable(pkgs, func(i, j int) bool {
+		iEmpty := pdFieldEmpty(pkgs[i], f.OrderBy)
+		jEmpty := pdFieldEmpty(pkgs[j], f.OrderBy)
+		if iEmpty != jEmpty {
+			return !iEmpty
+		}
+		if iEmpty && jEmpty {
+			return false
+		}
+
+		var less bool
+		switch f.OrderBy {
+		case SortName:
+			less = strings.ToLower(pkgs[i].Name) < strings.ToLower(pkgs[j].Name)
+		case SortVersion:
+			less = pkgs[i].Version < pkgs[j].Version
+		case SortSize:
+			less = ParseSizeToKB(pkgs[i].Size) < ParseSizeToKB(pkgs[j].Size)
+		case SortSection:
+			less = strings.ToLower(pkgs[i].Section) < strings.ToLower(pkgs[j].Section)
+		case SortArchitecture:
+			less = strings.ToLower(pkgs[i].Architecture) < strings.ToLower(pkgs[j].Architecture)
+		default:
+			return false
+		}
+		if f.OrderDesc {
+			return !less
+		}
+		return less
+	})
+}
+
+func pdFieldEmpty(p PackageData, col SortColumn) bool {
+	switch col {
+	case SortName:
+		return p.Name == ""
+	case SortVersion:
+		return p.Version == "" && p.NewVersion == ""
+	case SortSize:
+		return p.Size == "" || p.Size == "-"
+	case SortSection:
+		return p.Section == ""
+	case SortArchitecture:
+		return p.Architecture == ""
+	default:
+		return false
+	}
+}
+
+// SortPackages sorts a slice of model-level packages using the filter's ordering.
+func SortPackages(pkgs []PackageData, f Filter) {
+	Sort(pkgs, f)
 }

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -264,3 +264,136 @@ func TestFilterIsEmpty(t *testing.T) {
 		t.Error("filter with installed flag should not be empty")
 	}
 }
+
+func TestParseOrderByNameAsc(t *testing.T) {
+	f := Parse("order:name")
+	if f.OrderBy != SortName {
+		t.Errorf("expected SortName, got %d", f.OrderBy)
+	}
+	if f.OrderDesc {
+		t.Error("expected ascending order by default")
+	}
+}
+
+func TestParseOrderByNameDesc(t *testing.T) {
+	f := Parse("order:name:desc")
+	if f.OrderBy != SortName {
+		t.Errorf("expected SortName, got %d", f.OrderBy)
+	}
+	if !f.OrderDesc {
+		t.Error("expected descending order")
+	}
+}
+
+func TestParseOrderBySizeAsc(t *testing.T) {
+	f := Parse("order:size:asc")
+	if f.OrderBy != SortSize {
+		t.Errorf("expected SortSize, got %d", f.OrderBy)
+	}
+	if f.OrderDesc {
+		t.Error("expected ascending order")
+	}
+}
+
+func TestParseOrderByVersionDesc(t *testing.T) {
+	f := Parse("order:ver:desc")
+	if f.OrderBy != SortVersion {
+		t.Errorf("expected SortVersion, got %d", f.OrderBy)
+	}
+	if !f.OrderDesc {
+		t.Error("expected descending order")
+	}
+}
+
+func TestParseOrderCombinedWithFilter(t *testing.T) {
+	f := Parse("installed order:size:desc")
+	if f.Installed == nil || !*f.Installed {
+		t.Error("expected installed=true")
+	}
+	if f.OrderBy != SortSize {
+		t.Errorf("expected SortSize, got %d", f.OrderBy)
+	}
+	if !f.OrderDesc {
+		t.Error("expected descending order")
+	}
+}
+
+func TestParseOrderIsNotEmpty(t *testing.T) {
+	f := Parse("order:name")
+	if f.IsEmpty() {
+		t.Error("filter with order should not be empty")
+	}
+}
+
+func TestDescribeWithOrder(t *testing.T) {
+	f := Parse("order:name:desc")
+	desc := f.Describe()
+	if desc != "order:name:desc" {
+		t.Errorf("expected 'order:name:desc', got '%s'", desc)
+	}
+}
+
+func TestSortByNameAsc(t *testing.T) {
+	pkgs := []PackageData{
+		{Name: "zsh"},
+		{Name: "apt"},
+		{Name: "nano"},
+	}
+	f := Filter{OrderBy: SortName}
+	Sort(pkgs, f)
+	if pkgs[0].Name != "apt" || pkgs[1].Name != "nano" || pkgs[2].Name != "zsh" {
+		t.Errorf("unexpected order: %s, %s, %s", pkgs[0].Name, pkgs[1].Name, pkgs[2].Name)
+	}
+}
+
+func TestSortByNameDesc(t *testing.T) {
+	pkgs := []PackageData{
+		{Name: "apt"},
+		{Name: "zsh"},
+		{Name: "nano"},
+	}
+	f := Filter{OrderBy: SortName, OrderDesc: true}
+	Sort(pkgs, f)
+	if pkgs[0].Name != "zsh" || pkgs[1].Name != "nano" || pkgs[2].Name != "apt" {
+		t.Errorf("unexpected order: %s, %s, %s", pkgs[0].Name, pkgs[1].Name, pkgs[2].Name)
+	}
+}
+
+func TestSortBySizeAsc(t *testing.T) {
+	pkgs := []PackageData{
+		{Name: "big", Size: "10.0 MB"},
+		{Name: "small", Size: "100 kB"},
+		{Name: "med", Size: "1.0 MB"},
+	}
+	f := Filter{OrderBy: SortSize}
+	Sort(pkgs, f)
+	if pkgs[0].Name != "small" || pkgs[1].Name != "med" || pkgs[2].Name != "big" {
+		t.Errorf("unexpected order: %s, %s, %s", pkgs[0].Name, pkgs[1].Name, pkgs[2].Name)
+	}
+}
+
+func TestSortBySizeDesc(t *testing.T) {
+	pkgs := []PackageData{
+		{Name: "big", Size: "10.0 MB"},
+		{Name: "small", Size: "100 kB"},
+		{Name: "med", Size: "1.0 MB"},
+	}
+	f := Filter{OrderBy: SortSize, OrderDesc: true}
+	Sort(pkgs, f)
+	if pkgs[0].Name != "big" || pkgs[1].Name != "med" || pkgs[2].Name != "small" {
+		t.Errorf("unexpected order: %s, %s, %s", pkgs[0].Name, pkgs[1].Name, pkgs[2].Name)
+	}
+}
+
+func TestSortNoneDoesNothing(t *testing.T) {
+	pkgs := []PackageData{
+		{Name: "zsh"},
+		{Name: "apt"},
+		{Name: "nano"},
+	}
+	f := Filter{OrderBy: SortNone}
+	Sort(pkgs, f)
+	if pkgs[0].Name != "zsh" || pkgs[1].Name != "apt" || pkgs[2].Name != "nano" {
+		t.Errorf("SortNone should not change order: %s, %s, %s", pkgs[0].Name, pkgs[1].Name, pkgs[2].Name)
+	}
+}

--- a/internal/ui/components/packagelist.go
+++ b/internal/ui/components/packagelist.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mexirica/aptui/internal/filter"
 	"github.com/mexirica/aptui/internal/model"
 )
 
@@ -34,7 +35,7 @@ var (
 			Foreground(lipgloss.Color("#4A4A5A"))
 )
 
-func RenderPackageList(packages []model.Package, selected int, offset int, maxVisible int, width int, selectedSet map[string]bool) string {
+func RenderPackageList(packages []model.Package, selected int, offset int, maxVisible int, width int, selectedSet map[string]bool, sortCol ...filter.SortInfo) string {
 	if len(packages) == 0 {
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("#6C6C6C")).
 			Render("\n  No packages found.\n")
@@ -61,26 +62,55 @@ func RenderPackageList(packages []model.Package, selected int, offset int, maxVi
 	}
 
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#7D56F4"))
+	sortIndicatorStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFC107"))
+
+	// Determine sort indicator
+	var si filter.SortInfo
+	if len(sortCol) > 0 {
+		si = sortCol[0]
+	}
+	sortArrow := func(col filter.SortColumn) string {
+		if si.Column == col && col != filter.SortNone {
+			if si.Desc {
+				return " " + sortIndicatorStyle.Render("▼")
+			}
+			return " " + sortIndicatorStyle.Render("▲")
+		}
+		return ""
+	}
 
 	var b strings.Builder
 
+	nameArrow := sortArrow(filter.SortName)
+	versionArrow := sortArrow(filter.SortVersion)
+	sizeArrow := sortArrow(filter.SortSize)
+
 	padName := colName - 4
+	if nameArrow != "" {
+		padName -= 2 // arrow + space
+	}
 	if padName < 0 {
 		padName = 0
 	}
 	padVer := colVersion - 7
+	if versionArrow != "" {
+		padVer -= 2
+	}
 	if padVer < 0 {
 		padVer = 0
 	}
 	padSize := colSize - 4
+	if sizeArrow != "" {
+		padSize -= 2
+	}
 	if padSize < 0 {
 		padSize = 0
 	}
-	header := fmt.Sprintf("%s%s%s  %s%s  %s%s",
+	header := fmt.Sprintf("%s%s%s%s  %s%s%s  %s%s%s",
 		strings.Repeat(" ", prefixW),
-		headerStyle.Render("Name"), strings.Repeat(" ", padName),
-		headerStyle.Render("Version"), strings.Repeat(" ", padVer),
-		strings.Repeat(" ", padSize), headerStyle.Render("Size"))
+		headerStyle.Render("Name"), nameArrow, strings.Repeat(" ", padName),
+		headerStyle.Render("Version"), versionArrow, strings.Repeat(" ", padVer),
+		strings.Repeat(" ", padSize), headerStyle.Render("Size"), sizeArrow)
 	b.WriteString(header + "\n")
 	b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color("#7D56F4")).Render(strings.Repeat("─", width)) + "\n")
 


### PR DESCRIPTION
Resolves #2 

This pull request adds advanced column sorting to the package list, allowing users to sort packages by name, version, size, section, or architecture in both ascending and descending order. The sorting feature is fully integrated into the advanced filter syntax, updates the UI with clear sort indicators, and ensures packages with missing data are handled gracefully. Documentation and tests have also been updated to reflect and verify these enhancements.

**Advanced Filtering and Sorting Functionality:**

- Added support for sorting packages via the advanced filter bar using the `order:<column>[:asc|desc]` syntax, supporting columns such as name, version, size, section, and architecture. Sorting can be combined with other filters, and packages with missing metadata are always pushed to the end of the list.

- Updated the UI to display sort indicators (▲/▼) in the column headers for the active sort, and adjusted column padding to account for these indicators.

**Documentation Improvements:**

- Expanded the README and created detailed documentation in `docs/filter.md` to explain the new sorting syntax, provide usage examples, and describe how sorting interacts with filtering and missing data.

**Testing and Code Quality:**

- Added comprehensive unit tests for parsing, describing, and applying the new sort functionality, including various columns and sort directions, as well as integration with other filters.

**Internal Refactoring:**

- Refactored filter parsing, state, and sorting logic to support the new `SortColumn` and `SortInfo` types, and ensured sorting is applied consistently in the app logic and UI rendering.

These changes make the package list much more powerful and user-friendly, especially for users managing large sets of packages.