### PR TITLE
fix: clear status messages in transaction and error log tabs

### DIFF
--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -44,7 +44,7 @@ func (a *App) activateTab() tea.Cmd {
 		a.errlogItems = a.errlogStore.All()
 		a.errlogIdx = 0
 		a.errlogOffset = 0
-		a.status = fmt.Sprintf("%d errors (%s) ", len(a.errlogItems), tabDefs[a.activeTab].name)
+		a.status = ""
 		return nil
 	}
 	a.applyFilter()

--- a/internal/app/keypress.go
+++ b/internal/app/keypress.go
@@ -114,7 +114,7 @@ func (a App) openTransactions() (tea.Model, tea.Cmd) {
 	a.transactionIdx = 0
 	a.transactionOffset = 0
 	a.transactionDeps = nil
-	a.status = fmt.Sprintf("%d transactions | esc back | z undo | x redo ", len(a.transactionItems))
+	a.status = ""
 	var cmd tea.Cmd
 	if len(a.transactionItems) > 0 {
 		cmd = loadTransactionDepsCmd(0, a.transactionItems[0].Packages)

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -408,8 +408,8 @@ func (a App) renderPPAView(w int) string {
 func (a App) renderTransactionView(w int) string {
 	var footerParts []string
 	counterStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
-	footerParts = append(footerParts, counterStyle.Render())
 	footerParts = append(footerParts, components.RenderStatusBar(a.status, w))
+	footerParts = append(footerParts, counterStyle.Render(fmt.Sprintf("%d transactions | esc back | z undo | x redo ", len(a.transactionItems))))
 	footerParts = append(footerParts, ui.HelpStyle.Render(a.help.View(a.keys)))
 	footerView := lipgloss.JoinVertical(lipgloss.Left, footerParts...)
 	footerLines := strings.Count(footerView, "\n") + 1
@@ -453,8 +453,8 @@ func (a App) renderTransactionView(w int) string {
 
 	panelLines := strings.Count(panels, "\n") + 1
 	gap := a.height - 1 - panelLines - footerLines
-	if gap < 0 {
-		gap = 0
+	if gap < 1 {
+		gap = 1
 	}
 
 	return panels + strings.Repeat("\n", gap) + footerView
@@ -463,8 +463,8 @@ func (a App) renderTransactionView(w int) string {
 func (a App) renderErrorLogTab(w int, tabBar string) string {
 	var footerParts []string
 	counterStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
-	footerParts = append(footerParts, counterStyle.Render(fmt.Sprintf("  %d errors", len(a.errlogItems))))
 	footerParts = append(footerParts, components.RenderStatusBar(a.status, w))
+	footerParts = append(footerParts, counterStyle.Render(fmt.Sprintf("  %d errors", len(a.errlogItems))))
 	footerParts = append(footerParts, ui.HelpStyle.Render(a.help.View(a.keys)))
 	footerView := lipgloss.JoinVertical(lipgloss.Left, footerParts...)
 	footerLines := strings.Count(footerView, "\n") + 1


### PR DESCRIPTION
Fix #64

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes issue #64 by separating persistent UI info (transaction count, error count) from transient status messages. Previously, entering the transaction view or error-log tab would overwrite `a.status` with count/hint strings, causing stale messages from prior operations to appear, and making those counts disappear whenever a new status message arrived. The fix clears `a.status` on view entry and renders the counts in dedicated `counterStyle` footer elements instead.

Key changes:
- `helpers.go` / `keypress.go`: `a.status` is set to `""` instead of a formatted count string when entering the error-log and transaction views.
- `view.go` (`renderTransactionView`): The previously empty `counterStyle.Render()` call (a leftover no-op) is replaced with the transaction count/hint string; footer order is now status bar → counter → help.
- `view.go` (`renderErrorLogTab`): Footer order is reordered to status bar → error count → help, consistent with the transaction view.
- `view.go` (`renderTransactionView`): Minimum gap between panels and footer is changed from `0` to `1`, which may cause a 1-line layout overflow in terminal sizes where content exactly fills the viewport.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the core fix is correct and well-scoped, with one minor layout edge-case introduced by the gap change.
- The logic for separating transient status messages from persistent counter displays is sound and directly addresses the reported bug. The only concern is the `gap < 1` change in `renderTransactionView`, which can add an extra newline when content exactly fills the terminal height, potentially clipping the footer by one line in that edge case. All other changes are clean and correct.
- `internal/app/view.go` — specifically the `gap < 1` minimum change in `renderTransactionView`.

<sub>Reviews (1): Last reviewed commit: ["fix: clear status messages in transactio..."](https://github.com/mexirica/aptui/commit/e961469046a9ef355ffa94e1244fd30853925c25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26354616)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->