### PR TITLE
feat: add Termux support for sudo commands in client and fetch modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ echo "deb [signed-by=/usr/share/keyrings/aptui-archive-keyring.gpg] https://mexi
 sudo apt update && sudo apt install aptui
 ```
 
+### Termux (Android)
+
+```bash
+pkg install golang
+go install github.com/mexirica/aptui@latest
+```
+
+On Termux, `sudo` is not available and not needed — APTUI detects the Termux environment automatically and runs all commands without `sudo`. APT paths are resolved via the `$PREFIX` environment variable.
+
 ### Go
 
 ```bash
@@ -73,6 +82,12 @@ sudo mv aptui /usr/local/bin/
 ```bash
 # Run with sudo to allow package management operations (install, remove, upgrade)
 sudo aptui
+```
+
+On **Termux**, run without `sudo`:
+
+```bash
+aptui
 ```
 
 ## Tabs

--- a/docs/mirrors.md
+++ b/docs/mirrors.md
@@ -64,6 +64,8 @@ After selecting mirrors with `space`, press `enter` to apply. APTUI writes the s
 /etc/apt/sources.list.d/aptui-mirrors.list
 ```
 
+On **Termux**, the file is written to `$PREFIX/etc/apt/sources.list.d/aptui-mirrors.list` instead.
+
 The file includes entries for:
 - Main repository
 - Updates

--- a/docs/ppa.md
+++ b/docs/ppa.md
@@ -10,7 +10,7 @@
 
 ## Opening the PPA view
 
-Press **`Shift+P`** (uppercase P) on the main package screen. The PPA list will be displayed showing all PPA repositories found in `/etc/apt/sources.list.d/`.
+Press **`Shift+P`** (uppercase P) on the main package screen. The PPA list will be displayed showing all PPA repositories found in `/etc/apt/sources.list.d/` (or `$PREFIX/etc/apt/sources.list.d/` on Termux).
 
 ## Controls
 

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -15,6 +15,26 @@ import (
 
 var ErrAptFileMissing = errors.New("apt-file is not installed. Install it to list files of non-installed packages")
 
+// onTermux is true when running inside Termux, where sudo is unavailable.
+var onTermux = os.Getenv("TERMUX_VERSION") != "" || os.Getenv("TERMUX_API_VERSION") != ""
+
+// sudoCmd builds an exec.Cmd, prepending "sudo" unless running on Termux.
+func sudoCmd(name string, args ...string) *exec.Cmd {
+	if onTermux {
+		return exec.Command(name, args...)
+	}
+	return exec.Command("sudo", append([]string{name}, args...)...)
+}
+
+// sudoCmdSilent builds a non-interactive exec.Cmd (sudo -n), or a plain
+// command on Termux.
+func sudoCmdSilent(name string, args ...string) *exec.Cmd {
+	if onTermux {
+		return exec.Command(name, args...)
+	}
+	return exec.Command("sudo", append([]string{"-n", name}, args...)...)
+}
+
 // LoadAllAvailableInfo parses /var/lib/apt/lists/*_Packages files to bulk-load
 // metadata for all available packages. This is much faster than spawning
 // apt-cache show processes because it's pure file I/O with no process overhead.
@@ -115,14 +135,14 @@ func parsePackageFile(path string, info map[string]PackageInfo) {
 }
 
 func SilentUpdate() error {
-	cmd := exec.Command("sudo", "-n", "apt-get", "update", "-qq")
+	cmd := sudoCmdSilent("apt-get", "update", "-qq")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run()
 }
 
 func UpdateCmd() *exec.Cmd {
-	c := exec.Command("sudo", "apt-get", "update")
+	c := sudoCmd("apt-get", "update")
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -130,7 +150,7 @@ func UpdateCmd() *exec.Cmd {
 }
 
 func AutoRemoveCmd() *exec.Cmd {
-	c := exec.Command("sudo", "apt-get", "autoremove", "-y")
+	c := sudoCmd("apt-get", "autoremove", "-y")
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -231,7 +251,7 @@ func InstallBatchCmd(names []string, recommends, suggests bool) *exec.Cmd {
 		args = append(args, "--no-install-suggests")
 	}
 	args = append(args, names...)
-	c := exec.Command("sudo", args...)
+	c := sudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -258,7 +278,7 @@ func UpgradeBatchCmd(names []string, recommends, suggests bool) *exec.Cmd {
 		args = append(args, "--no-install-suggests")
 	}
 	args = append(args, names...)
-	c := exec.Command("sudo", args...)
+	c := sudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -277,7 +297,7 @@ func DistUpgradeCmd(recommends, suggests bool) *exec.Cmd {
 	} else {
 		args = append(args, "--no-install-suggests")
 	}
-	c := exec.Command("sudo", args...)
+	c := sudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -287,7 +307,7 @@ func DistUpgradeCmd(recommends, suggests bool) *exec.Cmd {
 // RemoveBatchCmd returns a remove command for multiple packages at once.
 func RemoveBatchCmd(names []string) *exec.Cmd {
 	args := append([]string{"apt-get", "remove", "-y"}, names...)
-	c := exec.Command("sudo", args...)
+	c := sudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -297,7 +317,7 @@ func RemoveBatchCmd(names []string) *exec.Cmd {
 // PurgeBatchCmd returns a purge command for multiple packages at once.
 func PurgeBatchCmd(names []string) *exec.Cmd {
 	args := append([]string{"apt-get", "purge", "-y"}, names...)
-	c := exec.Command("sudo", args...)
+	c := sudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -347,8 +367,8 @@ func ListHeld() ([]string, error) {
 
 // Hold holds packages via apt-mark hold.
 func Hold(names []string) error {
-	args := append([]string{"-n", "apt-mark", "hold"}, names...)
-	cmd := exec.Command("sudo", args...)
+	args := append([]string{"hold"}, names...)
+	cmd := sudoCmdSilent("apt-mark", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -359,8 +379,8 @@ func Hold(names []string) error {
 
 // Unhold unholds packages via apt-mark unhold.
 func Unhold(names []string) error {
-	args := append([]string{"-n", "apt-mark", "unhold"}, names...)
-	cmd := exec.Command("sudo", args...)
+	args := append([]string{"unhold"}, names...)
+	cmd := sudoCmdSilent("apt-mark", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -758,7 +778,7 @@ func ValidatePPA(input string) error {
 
 // AddPPACmd returns a command to add a PPA repository.
 func AddPPACmd(ppa string) *exec.Cmd {
-	c := exec.Command("sudo", "add-apt-repository", "-y", ppa)
+	c := sudoCmd("add-apt-repository", "-y", ppa)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -767,7 +787,7 @@ func AddPPACmd(ppa string) *exec.Cmd {
 
 // RemovePPACmd returns a command to remove a PPA repository.
 func RemovePPACmd(ppa string) *exec.Cmd {
-	c := exec.Command("sudo", "add-apt-repository", "-y", "--remove", ppa)
+	c := sudoCmd("add-apt-repository", "-y", "--remove", ppa)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -791,7 +811,7 @@ func SetPPAEnabled(ppa PPA, enabled bool) error {
 		return fmt.Errorf("unsupported source file format: %s", ppa.File)
 	}
 
-	cmd := exec.Command("sudo", "tee", ppa.File)
+	cmd := sudoCmd("tee", ppa.File)
 	cmd.Stdin = strings.NewReader(newContent)
 	cmd.Stdout = nil
 	var stderr bytes.Buffer

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -413,7 +413,7 @@ type PPA struct {
 
 // ListPPAs scans /etc/apt/sources.list.d/ for PPA entries.
 func ListPPAs() ([]PPA, error) {
-	dir := "/etc/apt/sources.list.d"
+	dir := platform.AptPath("sources.list.d")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("read sources.list.d: %w", err)
@@ -497,12 +497,13 @@ func ListAllRepos() ([]PPA, error) {
 	var repos []PPA
 	seen := make(map[string]bool)
 
-	// Scan /etc/apt/sources.list first
-	if data, err := os.ReadFile("/etc/apt/sources.list"); err == nil {
-		repos = parseListFile(string(data), "/etc/apt/sources.list", seen)
+	// Scan sources.list first
+	sourcesListPath := platform.AptPath("sources.list")
+	if data, err := os.ReadFile(sourcesListPath); err == nil {
+		repos = parseListFile(string(data), sourcesListPath, seen)
 	}
 
-	dir := "/etc/apt/sources.list.d"
+	dir := platform.AptPath("sources.list.d")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return repos, nil

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -11,29 +11,10 @@ import (
 	"strings"
 
 	"github.com/mexirica/aptui/internal/model"
+	"github.com/mexirica/aptui/internal/platform"
 )
 
 var ErrAptFileMissing = errors.New("apt-file is not installed. Install it to list files of non-installed packages")
-
-// onTermux is true when running inside Termux, where sudo is unavailable.
-var onTermux = os.Getenv("TERMUX_VERSION") != "" || os.Getenv("TERMUX_API_VERSION") != ""
-
-// sudoCmd builds an exec.Cmd, prepending "sudo" unless running on Termux.
-func sudoCmd(name string, args ...string) *exec.Cmd {
-	if onTermux {
-		return exec.Command(name, args...)
-	}
-	return exec.Command("sudo", append([]string{name}, args...)...)
-}
-
-// sudoCmdSilent builds a non-interactive exec.Cmd (sudo -n), or a plain
-// command on Termux.
-func sudoCmdSilent(name string, args ...string) *exec.Cmd {
-	if onTermux {
-		return exec.Command(name, args...)
-	}
-	return exec.Command("sudo", append([]string{"-n", name}, args...)...)
-}
 
 // LoadAllAvailableInfo parses /var/lib/apt/lists/*_Packages files to bulk-load
 // metadata for all available packages. This is much faster than spawning
@@ -135,14 +116,14 @@ func parsePackageFile(path string, info map[string]PackageInfo) {
 }
 
 func SilentUpdate() error {
-	cmd := sudoCmdSilent("apt-get", "update", "-qq")
+	cmd := platform.SudoCmdSilent("apt-get", "update", "-qq")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run()
 }
 
 func UpdateCmd() *exec.Cmd {
-	c := sudoCmd("apt-get", "update")
+	c := platform.SudoCmd("apt-get", "update")
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -150,7 +131,7 @@ func UpdateCmd() *exec.Cmd {
 }
 
 func AutoRemoveCmd() *exec.Cmd {
-	c := sudoCmd("apt-get", "autoremove", "-y")
+	c := platform.SudoCmd("apt-get", "autoremove", "-y")
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -251,7 +232,7 @@ func InstallBatchCmd(names []string, recommends, suggests bool) *exec.Cmd {
 		args = append(args, "--no-install-suggests")
 	}
 	args = append(args, names...)
-	c := sudoCmd(args[0], args[1:]...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -278,7 +259,7 @@ func UpgradeBatchCmd(names []string, recommends, suggests bool) *exec.Cmd {
 		args = append(args, "--no-install-suggests")
 	}
 	args = append(args, names...)
-	c := sudoCmd(args[0], args[1:]...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -297,7 +278,7 @@ func DistUpgradeCmd(recommends, suggests bool) *exec.Cmd {
 	} else {
 		args = append(args, "--no-install-suggests")
 	}
-	c := sudoCmd(args[0], args[1:]...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -307,7 +288,7 @@ func DistUpgradeCmd(recommends, suggests bool) *exec.Cmd {
 // RemoveBatchCmd returns a remove command for multiple packages at once.
 func RemoveBatchCmd(names []string) *exec.Cmd {
 	args := append([]string{"apt-get", "remove", "-y"}, names...)
-	c := sudoCmd(args[0], args[1:]...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -317,7 +298,7 @@ func RemoveBatchCmd(names []string) *exec.Cmd {
 // PurgeBatchCmd returns a purge command for multiple packages at once.
 func PurgeBatchCmd(names []string) *exec.Cmd {
 	args := append([]string{"apt-get", "purge", "-y"}, names...)
-	c := sudoCmd(args[0], args[1:]...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -368,7 +349,7 @@ func ListHeld() ([]string, error) {
 // Hold holds packages via apt-mark hold.
 func Hold(names []string) error {
 	args := append([]string{"hold"}, names...)
-	cmd := sudoCmdSilent("apt-mark", args...)
+	cmd := platform.SudoCmdSilent("apt-mark", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -380,7 +361,7 @@ func Hold(names []string) error {
 // Unhold unholds packages via apt-mark unhold.
 func Unhold(names []string) error {
 	args := append([]string{"unhold"}, names...)
-	cmd := sudoCmdSilent("apt-mark", args...)
+	cmd := platform.SudoCmdSilent("apt-mark", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -778,7 +759,7 @@ func ValidatePPA(input string) error {
 
 // AddPPACmd returns a command to add a PPA repository.
 func AddPPACmd(ppa string) *exec.Cmd {
-	c := sudoCmd("add-apt-repository", "-y", ppa)
+	c := platform.SudoCmd("add-apt-repository", "-y", ppa)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -787,7 +768,7 @@ func AddPPACmd(ppa string) *exec.Cmd {
 
 // RemovePPACmd returns a command to remove a PPA repository.
 func RemovePPACmd(ppa string) *exec.Cmd {
-	c := sudoCmd("add-apt-repository", "-y", "--remove", ppa)
+	c := platform.SudoCmd("add-apt-repository", "-y", "--remove", ppa)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -811,7 +792,7 @@ func SetPPAEnabled(ppa PPA, enabled bool) error {
 		return fmt.Errorf("unsupported source file format: %s", ppa.File)
 	}
 
-	cmd := sudoCmd("tee", ppa.File)
+	cmd := platform.SudoCmd("tee", ppa.File)
 	cmd.Stdin = strings.NewReader(newContent)
 	cmd.Stdout = nil
 	var stderr bytes.Buffer

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mexirica/aptui/internal/platform"
 )
 
 // Mirror represents a single package mirror with its test results.
@@ -333,12 +335,8 @@ func WriteSourcesListCmd(mirrors []Mirror, d Distro) *exec.Cmd {
 	}
 	content := strings.Join(lines, "\n") + "\n"
 
-	var c *exec.Cmd
-	if os.Getenv("TERMUX_VERSION") != "" || os.Getenv("TERMUX_API_VERSION") != "" {
-		c = exec.Command("tee", "/etc/apt/sources.list.d/aptui-mirrors.list")
-	} else {
-		c = exec.Command("sudo", "tee", "/etc/apt/sources.list.d/aptui-mirrors.list")
-	}
+	destPath := platform.AptPath("sources.list.d/aptui-mirrors.list")
+	c := platform.SudoCmd("tee", destPath)
 	c.Stdin = strings.NewReader(content)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -333,7 +333,12 @@ func WriteSourcesListCmd(mirrors []Mirror, d Distro) *exec.Cmd {
 	}
 	content := strings.Join(lines, "\n") + "\n"
 
-	c := exec.Command("sudo", "tee", "/etc/apt/sources.list.d/aptui-mirrors.list")
+	var c *exec.Cmd
+	if os.Getenv("TERMUX_VERSION") != "" || os.Getenv("TERMUX_API_VERSION") != "" {
+		c = exec.Command("tee", "/etc/apt/sources.list.d/aptui-mirrors.list")
+	} else {
+		c = exec.Command("sudo", "tee", "/etc/apt/sources.list.d/aptui-mirrors.list")
+	}
 	c.Stdin = strings.NewReader(content)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/internal/platform/termux.go
+++ b/internal/platform/termux.go
@@ -1,0 +1,39 @@
+package platform
+
+import (
+	"os"
+	"os/exec"
+)
+
+// OnTermux is true when running inside Termux, where sudo is unavailable.
+var OnTermux = os.Getenv("TERMUX_VERSION") != "" || os.Getenv("TERMUX_API_VERSION") != ""
+
+// SudoCmd builds an exec.Cmd, prepending "sudo" unless running on Termux.
+func SudoCmd(name string, args ...string) *exec.Cmd {
+	if OnTermux {
+		return exec.Command(name, args...)
+	}
+	return exec.Command("sudo", append([]string{name}, args...)...)
+}
+
+// SudoCmdSilent builds a non-interactive exec.Cmd (sudo -n), or a plain
+// command on Termux.
+func SudoCmdSilent(name string, args ...string) *exec.Cmd {
+	if OnTermux {
+		return exec.Command(name, args...)
+	}
+	return exec.Command("sudo", append([]string{"-n", name}, args...)...)
+}
+
+// AptPath returns the base APT configuration path. On Termux this is
+// $PREFIX/etc/apt; on standard Linux it is /etc/apt.
+func AptPath(subpath string) string {
+	if OnTermux {
+		prefix := os.Getenv("PREFIX")
+		if prefix == "" {
+			prefix = "/data/data/com.termux/files/usr"
+		}
+		return prefix + "/etc/apt/" + subpath
+	}
+	return "/etc/apt/" + subpath
+}


### PR DESCRIPTION
Fix #101.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `internal/platform/termux.go` package that centralizes Termux detection, sudo-command wrappers, and APT path resolution (using `$PREFIX`), then threads these helpers through `client.go` and `fetch.go`. It cleanly resolves the duplicated detection logic and wrong APT path raised in previous review rounds.

- **P1 — `LoadAllAvailableInfo` misses Termux path**: `filepath.Glob(\"/var/lib/apt/lists/*_Packages\")` always returns empty on Termux because apt lists live at `$PREFIX/var/lib/apt/lists/`. The new `platform.AptPath` helper only covers `/etc/apt/` paths, so a `VarLibAptPath` (or equivalent) is needed here.
- **P2 — `DetectDistro` reads `/etc/os-release` without prefix**: On Termux this file is at `$PREFIX/etc/os-release`; the failure is caught gracefully but makes mirror fetching unavailable on Termux.

<h3>Confidence Score: 4/5</h3>

Safe to merge for non-Termux users; Termux users will silently lose bulk package metadata due to the missed /var/lib/apt/lists path — fix the P1 before shipping to Termux.

The platform abstraction is well-designed and the two previously flagged issues are resolved. One new P1 remains: LoadAllAvailableInfo skips the PREFIX translation and returns nil on Termux, causing all bulk metadata to be missing. The P2 (DetectDistro) is handled gracefully but is still an incomplete Termux port.

internal/apt/client.go (LoadAllAvailableInfo — hardcoded /var/lib/apt/lists path); internal/fetch/fetch.go (DetectDistro — hardcoded /etc/os-release path)

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;develop&#39; into add-termux-s..."](https://github.com/mexirica/aptui/commit/0ba2576a8b616ce9ecc274ee0598ec9f39895dfb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27835605)</sub>

<!-- /greptile_comment -->