### PR TITLE
Merge from dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ echo "deb [signed-by=/usr/share/keyrings/aptui-archive-keyring.gpg] https://mexi
 sudo apt update && sudo apt install aptui
 ```
 
+### Termux (Android)
+
+```bash
+pkg install golang
+go install github.com/mexirica/aptui@latest
+```
+
+On Termux, `sudo` is not available and not needed — APTUI detects the Termux environment automatically and runs all commands without `sudo`. APT paths are resolved via the `$PREFIX` environment variable.
+
 ### Go
 
 ```bash
@@ -73,6 +82,12 @@ sudo mv aptui /usr/local/bin/
 ```bash
 # Run with sudo to allow package management operations (install, remove, upgrade)
 sudo aptui
+```
+
+On **Termux**, run without `sudo`:
+
+```bash
+aptui
 ```
 
 ## Tabs

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Navigate tabs with `tab` / `shift+tab`, or click on them.
 | `●` (green) | Installed |
 | `○` (gray) | Not installed |
 | `↑` (yellow) | Upgradable |
-| `⚠` (red) | Security update available |
+| `↑` (red) | Security update available |
 | `⊝` (orange) | Held |
 | `★` | Pinned |
 | `◈` | Essential |

--- a/docs/mirrors.md
+++ b/docs/mirrors.md
@@ -64,6 +64,8 @@ After selecting mirrors with `space`, press `enter` to apply. APTUI writes the s
 /etc/apt/sources.list.d/aptui-mirrors.list
 ```
 
+On **Termux**, the file is written to `$PREFIX/etc/apt/sources.list.d/aptui-mirrors.list` instead.
+
 The file includes entries for:
 - Main repository
 - Updates

--- a/docs/ppa.md
+++ b/docs/ppa.md
@@ -10,7 +10,7 @@
 
 ## Opening the PPA view
 
-Press **`Shift+P`** (uppercase P) on the main package screen. The PPA list will be displayed showing all PPA repositories found in `/etc/apt/sources.list.d/`.
+Press **`Shift+P`** (uppercase P) on the main package screen. The PPA list will be displayed showing all PPA repositories found in `/etc/apt/sources.list.d/` (or `$PREFIX/etc/apt/sources.list.d/` on Termux).
 
 ## Controls
 

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/mexirica/aptui/internal/model"
+	"github.com/mexirica/aptui/internal/platform"
 )
 
 var ErrAptFileMissing = errors.New("apt-file is not installed. Install it to list files of non-installed packages")
@@ -115,14 +116,14 @@ func parsePackageFile(path string, info map[string]PackageInfo) {
 }
 
 func SilentUpdate() error {
-	cmd := exec.Command("sudo", "-n", "apt-get", "update", "-qq")
+	cmd := platform.SudoCmdSilent("apt-get", "update", "-qq")
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	return cmd.Run()
 }
 
 func UpdateCmd() *exec.Cmd {
-	c := exec.Command("sudo", "apt-get", "update")
+	c := platform.SudoCmd("apt-get", "update")
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -130,7 +131,7 @@ func UpdateCmd() *exec.Cmd {
 }
 
 func AutoRemoveCmd() *exec.Cmd {
-	c := exec.Command("sudo", "apt-get", "autoremove", "-y")
+	c := platform.SudoCmd("apt-get", "autoremove", "-y")
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -231,7 +232,7 @@ func InstallBatchCmd(names []string, recommends, suggests bool) *exec.Cmd {
 		args = append(args, "--no-install-suggests")
 	}
 	args = append(args, names...)
-	c := exec.Command("sudo", args...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -258,7 +259,7 @@ func UpgradeBatchCmd(names []string, recommends, suggests bool) *exec.Cmd {
 		args = append(args, "--no-install-suggests")
 	}
 	args = append(args, names...)
-	c := exec.Command("sudo", args...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -277,7 +278,7 @@ func DistUpgradeCmd(recommends, suggests bool) *exec.Cmd {
 	} else {
 		args = append(args, "--no-install-suggests")
 	}
-	c := exec.Command("sudo", args...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -287,7 +288,7 @@ func DistUpgradeCmd(recommends, suggests bool) *exec.Cmd {
 // RemoveBatchCmd returns a remove command for multiple packages at once.
 func RemoveBatchCmd(names []string) *exec.Cmd {
 	args := append([]string{"apt-get", "remove", "-y"}, names...)
-	c := exec.Command("sudo", args...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -297,7 +298,7 @@ func RemoveBatchCmd(names []string) *exec.Cmd {
 // PurgeBatchCmd returns a purge command for multiple packages at once.
 func PurgeBatchCmd(names []string) *exec.Cmd {
 	args := append([]string{"apt-get", "purge", "-y"}, names...)
-	c := exec.Command("sudo", args...)
+	c := platform.SudoCmd(args[0], args[1:]...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -347,8 +348,8 @@ func ListHeld() ([]string, error) {
 
 // Hold holds packages via apt-mark hold.
 func Hold(names []string) error {
-	args := append([]string{"-n", "apt-mark", "hold"}, names...)
-	cmd := exec.Command("sudo", args...)
+	args := append([]string{"hold"}, names...)
+	cmd := platform.SudoCmdSilent("apt-mark", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -359,8 +360,8 @@ func Hold(names []string) error {
 
 // Unhold unholds packages via apt-mark unhold.
 func Unhold(names []string) error {
-	args := append([]string{"-n", "apt-mark", "unhold"}, names...)
-	cmd := exec.Command("sudo", args...)
+	args := append([]string{"unhold"}, names...)
+	cmd := platform.SudoCmdSilent("apt-mark", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -412,7 +413,7 @@ type PPA struct {
 
 // ListPPAs scans /etc/apt/sources.list.d/ for PPA entries.
 func ListPPAs() ([]PPA, error) {
-	dir := "/etc/apt/sources.list.d"
+	dir := platform.AptPath("sources.list.d")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("read sources.list.d: %w", err)
@@ -496,12 +497,13 @@ func ListAllRepos() ([]PPA, error) {
 	var repos []PPA
 	seen := make(map[string]bool)
 
-	// Scan /etc/apt/sources.list first
-	if data, err := os.ReadFile("/etc/apt/sources.list"); err == nil {
-		repos = parseListFile(string(data), "/etc/apt/sources.list", seen)
+	// Scan sources.list first
+	sourcesListPath := platform.AptPath("sources.list")
+	if data, err := os.ReadFile(sourcesListPath); err == nil {
+		repos = parseListFile(string(data), sourcesListPath, seen)
 	}
 
-	dir := "/etc/apt/sources.list.d"
+	dir := platform.AptPath("sources.list.d")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return repos, nil
@@ -758,7 +760,7 @@ func ValidatePPA(input string) error {
 
 // AddPPACmd returns a command to add a PPA repository.
 func AddPPACmd(ppa string) *exec.Cmd {
-	c := exec.Command("sudo", "add-apt-repository", "-y", ppa)
+	c := platform.SudoCmd("add-apt-repository", "-y", ppa)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -767,7 +769,7 @@ func AddPPACmd(ppa string) *exec.Cmd {
 
 // RemovePPACmd returns a command to remove a PPA repository.
 func RemovePPACmd(ppa string) *exec.Cmd {
-	c := exec.Command("sudo", "add-apt-repository", "-y", "--remove", ppa)
+	c := platform.SudoCmd("add-apt-repository", "-y", "--remove", ppa)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
@@ -791,7 +793,7 @@ func SetPPAEnabled(ppa PPA, enabled bool) error {
 		return fmt.Errorf("unsupported source file format: %s", ppa.File)
 	}
 
-	cmd := exec.Command("sudo", "tee", ppa.File)
+	cmd := platform.SudoCmd("tee", ppa.File)
 	cmd.Stdin = strings.NewReader(newContent)
 	cmd.Stdout = nil
 	var stderr bytes.Buffer

--- a/internal/fetch/fetch.go
+++ b/internal/fetch/fetch.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mexirica/aptui/internal/platform"
 )
 
 // Mirror represents a single package mirror with its test results.
@@ -333,7 +335,8 @@ func WriteSourcesListCmd(mirrors []Mirror, d Distro) *exec.Cmd {
 	}
 	content := strings.Join(lines, "\n") + "\n"
 
-	c := exec.Command("sudo", "tee", "/etc/apt/sources.list.d/aptui-mirrors.list")
+	destPath := platform.AptPath("sources.list.d/aptui-mirrors.list")
+	c := platform.SudoCmd("tee", destPath)
 	c.Stdin = strings.NewReader(content)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/internal/platform/termux.go
+++ b/internal/platform/termux.go
@@ -1,0 +1,39 @@
+package platform
+
+import (
+	"os"
+	"os/exec"
+)
+
+// OnTermux is true when running inside Termux, where sudo is unavailable.
+var OnTermux = os.Getenv("TERMUX_VERSION") != "" || os.Getenv("TERMUX_API_VERSION") != ""
+
+// SudoCmd builds an exec.Cmd, prepending "sudo" unless running on Termux.
+func SudoCmd(name string, args ...string) *exec.Cmd {
+	if OnTermux {
+		return exec.Command(name, args...)
+	}
+	return exec.Command("sudo", append([]string{name}, args...)...)
+}
+
+// SudoCmdSilent builds a non-interactive exec.Cmd (sudo -n), or a plain
+// command on Termux.
+func SudoCmdSilent(name string, args ...string) *exec.Cmd {
+	if OnTermux {
+		return exec.Command(name, args...)
+	}
+	return exec.Command("sudo", append([]string{"-n", name}, args...)...)
+}
+
+// AptPath returns the base APT configuration path. On Termux this is
+// $PREFIX/etc/apt; on standard Linux it is /etc/apt.
+func AptPath(subpath string) string {
+	if OnTermux {
+		prefix := os.Getenv("PREFIX")
+		if prefix == "" {
+			prefix = "/data/data/com.termux/files/usr"
+		}
+		return prefix + "/etc/apt/" + subpath
+	}
+	return "/etc/apt/" + subpath
+}

--- a/internal/ui/components/packagelist.go
+++ b/internal/ui/components/packagelist.go
@@ -120,7 +120,7 @@ func RenderPackageList(packages []model.Package, selected int, offset int, maxVi
 			badge = "⊝"
 			badgeStyle = lipgloss.NewStyle().Foreground(ui.ColorHeld).Bold(true)
 		} else if pkg.Upgradable && pkg.SecurityUpdate {
-			badge = "⚠"
+			badge = "↑"
 			badgeStyle = lipgloss.NewStyle().Foreground(ui.ColorDanger).Bold(true)
 		} else if pkg.Upgradable {
 			badge = "↑"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Termux (Android) support by introducing a new `platform` package that detects the Termux environment and provides `SudoCmd`, `SudoCmdSilent`, and `AptPath` helpers, replacing every hardcoded `sudo` invocation and `/etc/apt/` path in `client.go` and `fetch.go`. Documentation is updated accordingly. The refactoring is clean and internally consistent; the only notable change to watch is the security-update badge being replaced from `⚠` to `↑` (same glyph as the ordinary upgradable badge), which removes visual distinction for users in colorless terminals.

<h3>Confidence Score: 4/5</h3>

Safe to merge — no regressions on the standard Linux path; Termux path is additive and well-scoped.

All findings are P2: a cosmetic accessibility concern with the badge glyph change and a minor style suggestion for filepath.Join. No logic errors or behavioral regressions were found.

internal/ui/components/packagelist.go (badge glyph collision) and internal/platform/termux.go (path concatenation).

<sub>Reviews (1): Last reviewed commit: ["feat: add Termux support for sudo comman..."](https://github.com/mexirica/aptui/commit/c7e35fd89806b954f9c8264630a10b4ef07a5078) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30550143)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->