### PR TITLE
Feat  permit choose version and downgrade package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea), [Lip Gloss]
 - **Light / Dark theme** — auto-detects terminal background; override with `APTUI_THEME=light|dark` or toggle at runtime with `T`
 - **Pin favorites** — pin packages with `F` to keep them at the top of the list (★); pins are persisted across sessions
 - **Export / Import** — export all (`E`) or only manually installed (`M`) packages to JSON; import from file (`I`) to restore your environment ([docs](docs/portpkg.md))
+- **Version selection & downgrade** — press `v` to see all available versions of a package and install any of them, including older versions ([docs](docs/version.md))
+- **Phased update detection** — when upgrading, APTUI detects packages held back by APT's phased-updates mechanism and lets you force, skip, or cancel
 - **Hold packages** — hold (`H`) packages to prevent them from being upgraded
 - **File list** — view installed files for any package (`l`); uses `apt-file` for non-installed packages
 - **Inline detail panel** — shows package metadata (version, size, dependencies, homepage, status, etc.); scroll with `J`/`K` when content overflows
 - **Side-by-side & stacked layouts** — toggle between layouts with `L`; auto-selects based on terminal width (≥ 120 for side-by-side)
+- **Responsive dialogs** — confirmation overlays adapt to small terminal sizes, wrapping text and adjusting padding automatically
 - **Essential package protection** — essential packages cannot be removed or purged
+- **Termux support** — runs natively on Android via Termux without `sudo`; APT paths are resolved through `$PREFIX`
 - **Background updates** — silent `apt-get update` runs in the background after initial load
 
 ## Installation
@@ -184,6 +188,7 @@ See the full [search & filter documentation](docs/filter.md) for all available o
 | `E` | Export all installed packages to JSON file |
 | `M` | Export only manually installed packages to JSON file |
 | `I` | Import packages from JSON file |
+| `v` | Open version selector for current package ([docs](docs/version.md)) |
 | `U` | Run `apt-get update` |
 | `ctrl+r` | Refresh package list |
 
@@ -196,7 +201,7 @@ See the full [search & filter documentation](docs/filter.md) for all available o
 | `x` | Redo selected transaction |
 | `f` | Fetch and test mirrors |
 
-See: [Transaction History](docs/history.md) · [Mirror Fetch](docs/mirrors.md)
+See: [Transaction History](docs/history.md) · [Mirror Fetch](docs/mirrors.md) · [Version Selection](docs/version.md)
 
 ### PPA Management
 
@@ -252,6 +257,15 @@ Import confirmation:
 | `d` | Toggle detail view (paginated package list) |
 | `←` / `→` | Navigate detail pages |
 
+Phased upgrade confirmation (shown when phased packages are detected):
+
+| Key | Action |
+|---|---|
+| `y` | Force upgrade all packages (including phased) |
+| `s` | Skip phased packages, upgrade only non-phased |
+| `n` | Cancel upgrade |
+| `j` / `k` | Scroll package list in dialog |
+
 ## Data Storage
 
 APTUI stores its data in `~/.local/share/aptui/` (resolves the real user's home even under `sudo`):
@@ -291,6 +305,7 @@ export APTUI_THEME=light
 - [Transaction History](docs/history.md) — how operations are recorded, undo/redo rules
 - [Mirror Fetch](docs/mirrors.md) — supported distros, how mirrors are tested and applied
 - [Export & Import](docs/portpkg.md) — exporting and importing package lists
+- [Version Selection](docs/version.md) — viewing available versions, installing specific versions, downgrading
 
 ---
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -38,6 +38,7 @@ The following operations are saved to the transaction history:
 | `purge` | Package purge (remove + config files) |
 | `upgrade` | Individual package upgrade |
 | `upgrade-all` | Full system upgrade (`dist-upgrade`) |
+| `downgrade` | Package version downgrade |
 
 Operations that are **not recorded**: `update` (index refresh), `cleanup-all` (autoremove), PPA add/remove.
 
@@ -54,6 +55,8 @@ Each transaction entry contains:
 | Packages | List of packages affected |
 | Date | Timestamp of when the operation was executed |
 | Status | Success or failure |
+| FromVersion | Previous version (for upgrades/downgrades) |
+| ToVersion | New version installed (for upgrades/downgrades) |
 
 When a transaction is selected, the detail panel shows the full package list and dependencies (loaded via `apt-cache depends`).
 
@@ -70,9 +73,11 @@ Reverses the selected transaction:
 | `install` | Removes the installed packages |
 | `remove` | Reinstalls the removed packages |
 | `purge` | Reinstalls the purged packages |
+| `upgrade` | Reinstalls previous version (if version info available) |
+| `downgrade` | Reinstalls previous version |
 
 **Restrictions:**
-- **Upgrades cannot be undone** — downgrading is not supported.
+- **Full system upgrades (`upgrade-all`) cannot be undone** — use the version selector (`v`) to revert individual packages.
 - **Failed transactions cannot be undone** — only successful operations are reversible.
 - **Essential packages are protected** — undo will not remove essential system packages.
 

--- a/docs/version.md
+++ b/docs/version.md
@@ -1,0 +1,56 @@
+# Version Selection & Downgrade
+
+**aptui** lets you view all available versions of a package and install any of them — including older versions (downgrade).
+
+---
+
+## Opening the version selector
+
+Press **`v`** on any package in the list. APTUI queries `apt-cache policy` to load all available versions and opens an overlay listing them from newest to oldest.
+
+## Controls
+
+| Key              | Action                          |
+|------------------|---------------------------------|
+| `v`              | Open version selector           |
+| `↑` / `k`       | Move selection up               |
+| `↓` / `j`       | Move selection down             |
+| `pgup` / `ctrl+u` | Page up                       |
+| `pgdown` / `ctrl+d` | Page down                   |
+| `enter`          | Install selected version        |
+| `esc`            | Cancel and return to package list |
+
+---
+
+## Version list
+
+Each entry in the version list shows:
+
+| Column | Description |
+|--------|-------------|
+| Status | `●` if this version is currently installed, blank otherwise |
+| Version | The version string |
+| Origin | Repository origin (visible when terminal width > 60) |
+
+The currently installed version is highlighted, making it easy to identify which version you're running.
+
+---
+
+## Downgrading
+
+When you select a version older than the one currently installed, APTUI automatically detects it as a downgrade. The operation:
+
+- Uses `apt-get install <package>=<version> --allow-downgrades` to install the target version
+- Records both the original version (`FromVersion`) and the target version (`ToVersion`) in the transaction history
+- Shows "Downgrading" instead of "Installing" in the status bar
+
+---
+
+## Undo / Redo
+
+Version changes (upgrades and downgrades) are fully integrated with the transaction history:
+
+- **Undo (`z`)** — reverts the package to its previous version
+- **Redo (`x`)** — re-applies the version change
+
+See [Transaction History](history.md) for more details.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -76,15 +76,16 @@ type App struct {
 	sortColumn filter.SortColumn
 	sortDesc   bool
 
-	transactionStore  *history.Store
-	transactionItems  []history.Transaction
-	transactionIdx    int
-	transactionOffset int
-	transactionDeps   []string
-	pendingExecOp     string
-	pendingExecPkgs   []string
-	pendingExecCount  int
-	pendingExecFailed bool
+	transactionStore   *history.Store
+	transactionItems   []history.Transaction
+	transactionIdx     int
+	transactionOffset  int
+	transactionDeps    []string
+	pendingExecOp      string
+	pendingExecPkgs    []string
+	pendingExecCount   int
+	pendingExecFailed  bool
+	pendingExecVersion string
 
 	fetchView     bool
 	fetchDistro   fetch.Distro
@@ -148,8 +149,17 @@ type App struct {
 	fileListOffset int
 	fileListCache  map[string][]string
 
+	versionView        bool
+	versionPkg         string
+	versionItems       []apt.VersionInfo
+	versionIdx         int
+	versionOffset      int
+	versionPrevVer     string // version installed before version change
+	versionIsDowngrade bool
+
 	installRecommends bool
 	installSuggests   bool
+	autoUpdate        bool
 
 	sideBySide bool
 
@@ -214,6 +224,7 @@ func New() App {
 		essentialSet:      make(map[string]bool),
 		fileListCache:     make(map[string][]string),
 		installRecommends: true,
+		autoUpdate:        os.Getenv("APTUI_NO_UPDATE") == "",
 		sideBySide:        true,
 		pinStore:          ps,
 		pinnedSet:         ps.Set(),

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1912,15 +1912,18 @@ func TestFriendlyError(t *testing.T) {
 	tests := []struct {
 		name     string
 		err      error
+		stderr   string
 		expected string
 	}{
-		{name: "nil error", err: nil, expected: "unknown error"},
-		{name: "simple error", err: fmt.Errorf("something failed"), expected: "something failed"},
-		{name: "wrapped error", err: fmt.Errorf("wrap: %w", fmt.Errorf("inner")), expected: "wrap: inner"},
+		{name: "nil error", err: nil, stderr: "", expected: "unknown error"},
+		{name: "simple error", err: fmt.Errorf("something failed"), stderr: "", expected: "something failed"},
+		{name: "wrapped error", err: fmt.Errorf("wrap: %w", fmt.Errorf("inner")), stderr: "", expected: "wrap: inner"},
+		{name: "apt dependency error", err: fmt.Errorf("exit 100"), stderr: "Reading package lists...\nE: Unable to correct problems, you have held broken packages.", expected: "Unable to correct problems, you have held broken packages."},
+		{name: "stderr with depends line", err: fmt.Errorf("exit 100"), stderr: "The following packages have unmet dependencies:\n curl : Depends: libcurl4t64 (= 8.5.0-2) but 8.5.0-9 is to be installed\nE: Unable to correct problems", expected: "Unable to correct problems"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := friendlyError(tt.err)
+			got := friendlyError(tt.err, tt.stderr)
 			if got != tt.expected {
 				t.Errorf("friendlyError() = %q, want %q", got, tt.expected)
 			}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -294,3 +294,17 @@ func importPackagesCmd(path string) tea.Cmd {
 		return importFinishedMsg{names: names, path: resolvedPath}
 	}
 }
+
+func loadVersionsCmd(name string) tea.Cmd {
+	return func() tea.Msg {
+		versions, err := apt.ListVersions(name)
+		return versionListMsg{name: name, versions: versions, err: err}
+	}
+}
+
+func installVersionCmd(name, version string, recommends, suggests bool) tea.Cmd {
+	cmd := apt.InstallVersionCmd(name, version, recommends, suggests)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return execFinishedMsg{op: "install-version", name: name, err: err}
+	})
+}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -1,6 +1,10 @@
 package app
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -12,11 +16,19 @@ import (
 	"github.com/mexirica/aptui/internal/portpkg"
 )
 
+// execProcessWithStderr wraps tea.ExecProcess and captures stderr so we can
+// display a meaningful error message after bubbletea restores the terminal.
+func execProcessWithStderr(cmd *exec.Cmd, op, name string) tea.Cmd {
+	var buf bytes.Buffer
+	cmd.Stderr = io.MultiWriter(os.Stderr, &buf)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return execFinishedMsg{op: op, name: name, err: err, stderr: strings.TrimSpace(buf.String())}
+	})
+}
+
 func purgeBatchCmd(names []string) tea.Cmd {
 	cmd := apt.PurgeBatchCmd(names)
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "purge", name: strings.Join(names, " "), err: err}
-	})
+	return execProcessWithStderr(cmd, "purge", strings.Join(names, " "))
 }
 
 func reloadAllPackages() tea.Msg {
@@ -67,9 +79,7 @@ func reloadAllPackages() tea.Msg {
 
 func aptUpdateCmd() tea.Cmd {
 	cmd := apt.UpdateCmd()
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "update", name: "apt", err: err}
-	})
+	return execProcessWithStderr(cmd, "update", "apt")
 }
 
 func clearStatusAfter(d time.Duration) tea.Cmd {
@@ -126,9 +136,7 @@ func loadTransactionDepsCmd(txIdx int, packages []string) tea.Cmd {
 
 func upgradeAllPackagesCmd(names []string, recommends, suggests, includePhased bool) tea.Cmd {
 	cmd := apt.DistUpgradeCmd(recommends, suggests, includePhased)
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "upgrade-all", name: strings.Join(names, " "), err: err}
-	})
+	return execProcessWithStderr(cmd, "upgrade-all", strings.Join(names, " "))
 }
 
 func detectPhasedCmd() tea.Cmd {
@@ -140,23 +148,17 @@ func detectPhasedCmd() tea.Cmd {
 
 func installBatchCmd(names []string, recommends, suggests bool) tea.Cmd {
 	cmd := apt.InstallBatchCmd(names, recommends, suggests)
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "install", name: strings.Join(names, " "), err: err}
-	})
+	return execProcessWithStderr(cmd, "install", strings.Join(names, " "))
 }
 
 func removeBatchCmd(names []string) tea.Cmd {
 	cmd := apt.RemoveBatchCmd(names)
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "remove", name: strings.Join(names, " "), err: err}
-	})
+	return execProcessWithStderr(cmd, "remove", strings.Join(names, " "))
 }
 
 func upgradeBatchCmd(names []string, recommends, suggests bool) tea.Cmd {
 	cmd := apt.UpgradeBatchCmd(names, recommends, suggests)
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "upgrade", name: strings.Join(names, " "), err: err}
-	})
+	return execProcessWithStderr(cmd, "upgrade", strings.Join(names, " "))
 }
 
 func fetchMirrorListCmd() tea.Cmd {
@@ -192,9 +194,7 @@ func loadAutoremovableCmd() tea.Cmd {
 
 func autoremoveAllCmd(names []string) tea.Cmd {
 	cmd := apt.AutoRemoveCmd()
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "cleanup-all", name: strings.Join(names, " "), err: err}
-	})
+	return execProcessWithStderr(cmd, "cleanup-all", strings.Join(names, " "))
 }
 
 func listPPAsCmd() tea.Cmd {
@@ -206,16 +206,12 @@ func listPPAsCmd() tea.Cmd {
 
 func addPPACmd(ppa string) tea.Cmd {
 	cmd := apt.AddPPACmd(ppa)
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "ppa-add", name: ppa, err: err}
-	})
+	return execProcessWithStderr(cmd, "ppa-add", ppa)
 }
 
 func removePPACmd(ppa string) tea.Cmd {
 	cmd := apt.RemovePPACmd(ppa)
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "ppa-remove", name: ppa, err: err}
-	})
+	return execProcessWithStderr(cmd, "ppa-remove", ppa)
 }
 
 func togglePPACmd(ppa apt.PPA) tea.Cmd {
@@ -240,14 +236,14 @@ func loadHeldCmd() tea.Cmd {
 func holdBatchCmd(names []string) tea.Cmd {
 	return func() tea.Msg {
 		err := apt.Hold(names)
-		return holdFinishedMsg{op: "hold", err: err}
+		return holdFinishedMsg{op: "hold", names: names, err: err}
 	}
 }
 
 func unholdBatchCmd(names []string) tea.Cmd {
 	return func() tea.Msg {
 		err := apt.Unhold(names)
-		return holdFinishedMsg{op: "unhold", err: err}
+		return holdFinishedMsg{op: "unhold", names: names, err: err}
 	}
 }
 
@@ -311,7 +307,5 @@ func loadVersionsCmd(name string) tea.Cmd {
 
 func installVersionCmd(name, version string, recommends, suggests bool) tea.Cmd {
 	cmd := apt.InstallVersionCmd(name, version, recommends, suggests)
-	return tea.ExecProcess(cmd, func(err error) tea.Msg {
-		return execFinishedMsg{op: "install-version", name: name, err: err}
-	})
+	return execProcessWithStderr(cmd, "install-version", name)
 }

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -512,15 +512,15 @@ func (a App) packageListHeight() int {
 	if a.sideBySide {
 		// In side-by-side: inner height of main panel = panelH - 2 (border) - 2 (header+separator)
 		h := a.sideMainPanelHeight() - 2 - 2
-		if h < 5 {
-			h = 5
+		if h < 1 {
+			h = 1
 		}
 		return h
 	}
 	// Stacked: inner height of list panel minus header+separator
 	h := a.stackedListPanelHeight() - 2 - 2
-	if h < 5 {
-		h = 5
+	if h < 1 {
+		h = 1
 	}
 	return h
 }

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -594,15 +594,22 @@ func (a App) phasedMaxVisible() int {
 	return max
 }
 
-func friendlyError(err error) string {
+func friendlyError(err error, stderr string) string {
 	if err == nil {
 		return "unknown error"
 	}
+
+	// Use captured stderr if available (preferred over ExitError.Stderr
+	// because we capture it via MultiWriter).
+	if stderr != "" {
+		return extractAptError(stderr)
+	}
+
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
-		stderr := strings.TrimSpace(string(exitErr.Stderr))
-		if stderr != "" {
-			return stderr
+		s := strings.TrimSpace(string(exitErr.Stderr))
+		if s != "" {
+			return extractAptError(s)
 		}
 		switch exitErr.ExitCode() {
 		case 100:
@@ -614,4 +621,35 @@ func friendlyError(err error) string {
 		}
 	}
 	return err.Error()
+}
+
+// extractAptError parses apt stderr output and returns the most relevant
+// user-facing error line(s).
+func extractAptError(stderr string) string {
+	lines := strings.Split(stderr, "\n")
+
+	// Look for dependency/held-package errors first.
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "E: ") {
+			return strings.TrimPrefix(trimmed, "E: ")
+		}
+	}
+
+	// Look for "Depends:" lines (unmet dependencies).
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "Depends:") || strings.Contains(trimmed, "Conflicts:") {
+			return trimmed
+		}
+	}
+
+	// Fallback: last non-empty line.
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return stderr
 }

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -587,9 +587,14 @@ func (a App) fileListHeight() int {
 
 func (a App) phasedMaxVisible() int {
 	// Reserve space for overlay chrome (title, explanation, hints, borders, padding).
-	max := a.height - 20
-	if max < 5 {
-		max = 5
+	// Compact mode omits explanation and reduces padding, needing less chrome.
+	overhead := 20
+	if a.height < 20 {
+		overhead = 10 // compact: no explanation, no vertical padding
+	}
+	max := a.height - overhead
+	if max < 3 {
+		max = 3
 	}
 	return max
 }

--- a/internal/app/keypress_actions.go
+++ b/internal/app/keypress_actions.go
@@ -163,6 +163,9 @@ func (a App) dispatchPackageAction(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, boo
 	case "c":
 		model, cmd := a.cleanupAllPackages()
 		return model, cmd, true
+	case "v":
+		model, cmd := a.openVersionSelector()
+		return model, cmd, true
 	}
 	return a, nil, false
 }
@@ -385,6 +388,20 @@ func (a App) holdSelectedPackages() (tea.Model, tea.Cmd) {
 	}
 	a.status = fmt.Sprintf("Unholding %d packages...", len(unholdNames))
 	return a, unholdBatchCmd(unholdNames)
+}
+
+func (a App) openVersionSelector() (tea.Model, tea.Cmd) {
+	if len(a.filtered) == 0 || a.selectedIdx >= len(a.filtered) {
+		return a, nil
+	}
+	pkg := a.filtered[a.selectedIdx]
+	a.versionPkg = pkg.Name
+	a.versionItems = nil
+	a.versionIdx = 0
+	a.versionOffset = 0
+	a.loading = true
+	a.status = fmt.Sprintf("Loading versions for %s...", pkg.Name)
+	return a, loadVersionsCmd(pkg.Name)
 }
 
 func (a App) switchTab(msg tea.KeyPressMsg) (tea.Model, tea.Cmd, bool) {

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -18,7 +18,7 @@ const (
 
 func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	// Block mouse interactions while a modal dialog is open.
-	if a.importConfirm || a.removeConfirm || a.upgradeConfirm {
+	if a.importConfirm || a.removeConfirm || a.upgradeConfirm || a.versionView {
 		return a, nil
 	}
 	a.exportConfirm = false

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -12,8 +12,8 @@ import (
 // Stacked layout: info panel (5 rows) sits above the list panel.
 // tabBar(1) + gap(1) + infoPanel(5) + gap(1) = 8, then border(1) + header(1) + sep(1).
 const (
-	packageListHeaderY = 8  // first row inside list panel (header)
-	packageListStartY  = 10 // first package item row
+	packageListHeaderY = 8  
+	packageListStartY  = 10
 )
 
 func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -17,6 +17,10 @@ const (
 )
 
 func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	// Block mouse interactions while a modal dialog is open.
+	if a.importConfirm || a.removeConfirm || a.upgradeConfirm {
+		return a, nil
+	}
 	a.exportConfirm = false
 	m := msg.Mouse()
 

--- a/internal/app/keypress_transaction.go
+++ b/internal/app/keypress_transaction.go
@@ -105,7 +105,7 @@ func (a App) undoTransaction() (tea.Model, tea.Cmd) {
 	if tx.FromVersion != "" && tx.ToVersion != "" && len(tx.Packages) == 1 {
 		pkgName := tx.Packages[0]
 		a.versionPrevVer = tx.ToVersion
-		a.versionIsDowngrade = true
+		a.versionIsDowngrade = tx.Operation != history.OpDowngrade
 		a.pendingExecOp = "install-version"
 		a.pendingExecPkgs = []string{pkgName}
 		a.pendingExecVersion = tx.FromVersion

--- a/internal/app/keypress_transaction.go
+++ b/internal/app/keypress_transaction.go
@@ -101,8 +101,22 @@ func (a App) undoTransaction() (tea.Model, tea.Cmd) {
 		a.status = ui.ErrorStyle.Render("Cannot undo a failed transaction.")
 		return a, nil
 	}
+	// Handle version change undo (downgrade/install-version with version info)
+	if tx.FromVersion != "" && tx.ToVersion != "" && len(tx.Packages) == 1 {
+		pkgName := tx.Packages[0]
+		a.versionPrevVer = tx.ToVersion
+		a.versionIsDowngrade = true
+		a.pendingExecOp = "install-version"
+		a.pendingExecPkgs = []string{pkgName}
+		a.pendingExecVersion = tx.FromVersion
+		a.pendingExecCount = 1
+		a.activeTab = tabAll
+		a.loading = true
+		a.status = fmt.Sprintf("Reverting %s from %s to %s...", pkgName, tx.ToVersion, tx.FromVersion)
+		return a, installVersionCmd(pkgName, tx.FromVersion, a.installRecommends, a.installSuggests)
+	}
 	if tx.Operation == history.OpUpgradeAll || tx.Operation == history.OpUpgrade {
-		a.status = ui.ErrorStyle.Render("Cannot undo upgrade: downgrade is not supported.")
+		a.status = ui.ErrorStyle.Render("Cannot undo upgrade: use version selector (v) to downgrade.")
 		return a, nil
 	}
 	undoOp := history.UndoOperation(tx.Operation)
@@ -179,6 +193,15 @@ func (a App) redoTransaction() (tea.Model, tea.Cmd) {
 		cmd = upgradeBatchCmd(pkgs, a.installRecommends, a.installSuggests)
 	case history.OpPurge:
 		cmd = purgeBatchCmd(pkgs)
+	case history.OpDowngrade:
+		if tx.ToVersion != "" && len(pkgs) == 1 {
+			a.versionPrevVer = tx.FromVersion
+			a.versionIsDowngrade = true
+			a.pendingExecVersion = tx.ToVersion
+			cmd = installVersionCmd(pkgs[0], tx.ToVersion, a.installRecommends, a.installSuggests)
+		} else {
+			cmd = installBatchCmd(pkgs, a.installRecommends, a.installSuggests)
+		}
 	}
 	a.pendingExecOp = string(tx.Operation)
 	a.pendingExecPkgs = pkgs

--- a/internal/app/keypress_version.go
+++ b/internal/app/keypress_version.go
@@ -110,7 +110,11 @@ func (a App) onVersionListLoaded(msg versionListMsg) (tea.Model, tea.Cmd) {
 		a.status = ui.ErrorStyle.Render(fmt.Sprintf("Error loading versions: %v", msg.err))
 		return a, nil
 	}
-	if len(msg.versions) <= 1 {
+	if len(msg.versions) == 0 {
+		a.status = fmt.Sprintf("No versions found for %s in configured repositories.", msg.name)
+		return a, nil
+	}
+	if len(msg.versions) == 1 {
 		a.status = fmt.Sprintf("Only 1 version available for %s in configured repositories.", msg.name)
 		return a, nil
 	}

--- a/internal/app/keypress_version.go
+++ b/internal/app/keypress_version.go
@@ -1,0 +1,143 @@
+package app
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mexirica/aptui/internal/ui"
+)
+
+func (a App) onVersionKeypress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		return a, tea.Quit
+	case "esc":
+		a.versionView = false
+		a.versionItems = nil
+		a.versionPkg = ""
+		a.status = fmt.Sprintf("%d packages ", len(a.filtered))
+		return a, nil
+	case "j", "down":
+		if a.versionIdx < len(a.versionItems)-1 {
+			a.versionIdx++
+			a.adjustVersionScroll()
+		}
+		return a, nil
+	case "k", "up":
+		if a.versionIdx > 0 {
+			a.versionIdx--
+			a.adjustVersionScroll()
+		}
+		return a, nil
+	case "ctrl+d", "pgdown":
+		a.versionIdx += a.versionListHeight()
+		if a.versionIdx >= len(a.versionItems) {
+			a.versionIdx = len(a.versionItems) - 1
+		}
+		if a.versionIdx < 0 {
+			a.versionIdx = 0
+		}
+		a.adjustVersionScroll()
+		return a, nil
+	case "ctrl+u", "pgup":
+		a.versionIdx -= a.versionListHeight()
+		if a.versionIdx < 0 {
+			a.versionIdx = 0
+		}
+		a.adjustVersionScroll()
+		return a, nil
+	case "enter":
+		return a.installSelectedVersion()
+	}
+	return a, nil
+}
+
+func (a App) installSelectedVersion() (tea.Model, tea.Cmd) {
+	if len(a.versionItems) == 0 || a.versionIdx >= len(a.versionItems) {
+		return a, nil
+	}
+	ver := a.versionItems[a.versionIdx]
+	if ver.Installed {
+		a.status = fmt.Sprintf("Version %s is already installed.", ver.Version)
+		return a, nil
+	}
+
+	// Determine current version for undo tracking
+	currentVer := ""
+	isDowngrade := false
+	if idx, ok := a.pkgIndex[a.versionPkg]; ok {
+		pkg := a.allPackages[idx]
+		if pkg.Installed {
+			currentVer = pkg.Version
+			// apt-cache policy lists versions newest-first.
+			// If we find currentVer before the target, the target is older → downgrade.
+			for _, v := range a.versionItems {
+				if v.Version == currentVer {
+					isDowngrade = true
+					break
+				}
+				if v.Version == ver.Version {
+					isDowngrade = false
+					break
+				}
+			}
+		}
+	}
+
+	a.versionPrevVer = currentVer
+	a.versionIsDowngrade = isDowngrade
+	a.pendingExecOp = "install-version"
+	a.pendingExecPkgs = []string{a.versionPkg}
+	a.pendingExecVersion = ver.Version
+	a.pendingExecCount = 1
+	a.loading = true
+	a.versionView = false
+
+	opLabel := "Installing"
+	if isDowngrade {
+		opLabel = "Downgrading"
+	}
+	a.status = fmt.Sprintf("%s %s to version %s...", opLabel, a.versionPkg, ver.Version)
+
+	return a, installVersionCmd(a.versionPkg, ver.Version, a.installRecommends, a.installSuggests)
+}
+
+func (a App) onVersionListLoaded(msg versionListMsg) (tea.Model, tea.Cmd) {
+	a.loading = false
+	if msg.err != nil {
+		a.errlogStore.Log("version-list", fmt.Sprintf("%s: %v", msg.name, msg.err))
+		a.status = ui.ErrorStyle.Render(fmt.Sprintf("Error loading versions: %v", msg.err))
+		return a, nil
+	}
+	if len(msg.versions) <= 1 {
+		a.status = fmt.Sprintf("Only 1 version available for %s in configured repositories.", msg.name)
+		return a, nil
+	}
+	// Only now open the version view
+	a.versionView = true
+	a.versionItems = msg.versions
+	a.versionPkg = msg.name
+	a.versionIdx = 0
+	a.versionOffset = 0
+	a.status = fmt.Sprintf("%d versions available for %s", len(msg.versions), msg.name)
+	return a, nil
+}
+
+func (a *App) adjustVersionScroll() {
+	maxVisible := a.versionListHeight()
+	if a.versionIdx < a.versionOffset {
+		a.versionOffset = a.versionIdx
+	}
+	if a.versionIdx >= a.versionOffset+maxVisible {
+		a.versionOffset = a.versionIdx - maxVisible + 1
+	}
+}
+
+func (a App) versionListHeight() int {
+	h := a.height - 10
+	if h < 5 {
+		h = 5
+	}
+	return h
+}

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -101,3 +101,9 @@ type fileListLoadedMsg struct {
 	files []string
 	err   error
 }
+
+type versionListMsg struct {
+	name     string
+	versions []apt.VersionInfo
+	err      error
+}

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -27,9 +27,10 @@ type detailLoadedMsg struct {
 }
 
 type execFinishedMsg struct {
-	op   string
-	name string
-	err  error
+	op     string
+	name   string
+	err    error
+	stderr string
 }
 
 type fetchMirrorsMsg struct {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -430,6 +430,8 @@ func (a App) onExecFinished(msg execFinishedMsg) (tea.Model, tea.Cmd) {
 			a.versionPrevVer = ""
 			a.pendingExecVersion = ""
 			a.versionIsDowngrade = false
+		} else if op == "install-version" {
+			a.transactionStore.Record(history.OpInstall, pkgs, success)
 		} else {
 			a.transactionStore.Record(op, pkgs, success)
 		}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -93,7 +93,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case versionListMsg:
 		return a.onVersionListLoaded(msg)
-		
+
 	case fetchMirrorsMsg:
 		return a.onMirrorListLoaded(msg)
 
@@ -431,7 +431,8 @@ func (a App) onExecFinished(msg execFinishedMsg) (tea.Model, tea.Cmd) {
 			a.pendingExecVersion = ""
 			a.versionIsDowngrade = false
 		} else if op == "install-version" {
-			a.transactionStore.Record(history.OpInstall, pkgs, success)
+			a.transactionStore.RecordVersionChange(history.OpInstall, pkgs, "", a.pendingExecVersion, success)
+			a.pendingExecVersion = ""
 		} else {
 			a.transactionStore.Record(op, pkgs, success)
 		}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -442,8 +442,8 @@ func (a App) onExecFinished(msg execFinishedMsg) (tea.Model, tea.Cmd) {
 	a.pendingExecFailed = false
 
 	if !success {
-		a.errlogStore.Log("exec", fmt.Sprintf("%s %s: %s", msg.op, msg.name, friendlyError(msg.err)))
-		a.status = ui.ErrorStyle.Render(fmt.Sprintf("Error (%s %s): %s", msg.op, msg.name, friendlyError(msg.err)))
+		a.errlogStore.Log("exec", fmt.Sprintf("%s %s: %s", msg.op, msg.name, friendlyError(msg.err, msg.stderr)))
+		a.status = ui.ErrorStyle.Render(fmt.Sprintf("Error (%s %s): %s", msg.op, msg.name, friendlyError(msg.err, msg.stderr)))
 	} else if msg.op == "update" {
 		a.status = ui.SuccessStyle.Render("✔ apt update completed!")
 	} else if msg.op == "cleanup-all" {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -31,6 +31,7 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.height = msg.Height
 		a.help.SetWidth(msg.Width)
 		a.sideBySide = msg.Width >= sideMinWidth
+		a.adjustPackageScroll()
 		return a, nil
 
 	case spinner.TickMsg:
@@ -87,6 +88,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fileListLoadedMsg:
 		return a.onFileListLoaded(msg)
 
+	case versionListMsg:
+		return a.onVersionListLoaded(msg)
+
 	case fetchMirrorsMsg:
 		return a.onMirrorListLoaded(msg)
 
@@ -102,6 +106,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.KeyPressMsg:
+		if a.versionView {
+			return a.onVersionKeypress(msg)
+		}
 		if a.fetchView {
 			return a.onFetchKeypress(msg)
 		}
@@ -220,7 +227,7 @@ func (a App) onAllPackagesLoaded(msg allPackagesMsg) (tea.Model, tea.Cmd) {
 		a.pendingStatus = defaultStatus
 	}
 	cmds := []tea.Cmd{a.updateSelectionCmd()}
-	if firstLoad {
+	if firstLoad && a.autoUpdate {
 		cmds = append(cmds, silentUpdateCmd())
 	}
 	return a, tea.Batch(cmds...)
@@ -411,7 +418,18 @@ func (a App) onExecFinished(msg execFinishedMsg) (tea.Model, tea.Cmd) {
 		pkgs = []string{msg.name}
 	}
 	if op != "update" && op != "cleanup-all" && op != "ppa-add" && op != "ppa-remove" {
-		a.transactionStore.Record(op, pkgs, success)
+		if (op == history.OpDowngrade || op == "install-version") && a.versionPrevVer != "" {
+			actualOp := history.OpDowngrade
+			if !a.versionIsDowngrade {
+				actualOp = history.OpInstall
+			}
+			a.transactionStore.RecordVersionChange(actualOp, pkgs, a.versionPrevVer, a.pendingExecVersion, success)
+			a.versionPrevVer = ""
+			a.pendingExecVersion = ""
+			a.versionIsDowngrade = false
+		} else {
+			a.transactionStore.Record(op, pkgs, success)
+		}
 	}
 	a.pendingExecPkgs = nil
 	a.pendingExecOp = ""
@@ -434,7 +452,11 @@ func (a App) onExecFinished(msg execFinishedMsg) (tea.Model, tea.Cmd) {
 	a.statusLock = time.Now()
 
 	if success && msg.op != "update" && msg.op != "ppa-add" && msg.op != "ppa-remove" {
-		a.applyOptimisticUpdate(msg.op, pkgs)
+		applyOp := msg.op
+		if applyOp == "install-version" || applyOp == "downgrade" {
+			applyOp = "install"
+		}
+		a.applyOptimisticUpdate(applyOp, pkgs)
 	}
 
 	a.fileListCache = make(map[string][]string)

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -307,8 +307,7 @@ func (a App) applyUpgradeConfirmOverlay(page string, w int) string {
 	hintText := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
 	hints := yKey + hintText.Render(" force all  ") + sKey + hintText.Render(" skip phased  ") + nKey + hintText.Render(" cancel")
 
-	var content string
-	content = lipgloss.JoinVertical(lipgloss.Center, title, "", body, "", hints)
+	content := lipgloss.JoinVertical(lipgloss.Center, title, "", body, "", hints)
 
 	padV := 1
 	if compact {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -26,10 +26,18 @@ func (a App) View() tea.View {
 		return a.newView(fmt.Sprintf("Updating and loading packages %s", a.spinner.View()))
 	}
 
+	if a.width < 20 || a.height < 5 {
+		return a.newView("Terminal too small. Please resize.")
+	}
+
 	w := a.width
 
 	if a.fetchView {
 		return a.newView(a.renderFetchView(w))
+	}
+
+	if a.versionView {
+		return a.newView(a.renderVersionView(w))
 	}
 
 	tabBar := a.renderTabBar()
@@ -482,6 +490,53 @@ func (a App) renderPPAView(w int, tabBar string) string {
 	}
 
 	return tabBar + "\n\n" + panels + strings.Repeat("\n", gap) + statusBarView
+}
+
+func (a App) renderVersionView(w int) string {
+	if w < 20 {
+		w = 20
+	}
+	if a.height < 10 {
+		return "Terminal too small"
+	}
+
+	var statusParts []string
+	statusParts = append(statusParts, components.RenderStatusBar(a.status, w))
+	counterStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
+	statusParts = append(statusParts, counterStyle.Render(fmt.Sprintf("%d versions | enter install | esc cancel ", len(a.versionItems))))
+	statusBarView := lipgloss.JoinVertical(lipgloss.Left, statusParts...)
+	statusBarLines := strings.Count(statusBarView, "\n") + 1
+
+	panelH := a.height - 2 - statusBarLines
+	if panelH < 7 {
+		panelH = 7
+	}
+	innerH := panelH - 2
+
+	maxVisible := innerH - 4
+	if maxVisible < 3 {
+		maxVisible = 3
+	}
+
+	if a.loading {
+		content := fmt.Sprintf("\n  Loading versions for %s %s\n", a.versionPkg, a.spinner.View())
+		panel := renderTitledPanel("Version Selection", "", content, w, panelH)
+		gap := a.height - strings.Count(panel, "\n") - statusBarLines - 1
+		if gap < 0 {
+			gap = 0
+		}
+		return panel + strings.Repeat("\n", gap) + statusBarView
+	}
+
+	listContent := components.RenderVersionList(a.versionPkg, a.versionItems, a.versionIdx, a.versionOffset, maxVisible, w-4)
+	countText := lipgloss.NewStyle().Foreground(ui.ColorSubtle).Render(fmt.Sprintf("%d", len(a.versionItems)))
+	panel := renderTitledPanel("Version Selection", countText, listContent, w, panelH)
+
+	gap := a.height - strings.Count(panel, "\n") - statusBarLines - 1
+	if gap < 0 {
+		gap = 0
+	}
+	return panel + strings.Repeat("\n", gap) + statusBarView
 }
 
 func (a App) renderTransactionView(w int, tabBar string) string {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -234,6 +234,8 @@ func (a App) applyRemoveConfirmOverlay(page string, w int) string {
 func (a App) applyUpgradeConfirmOverlay(page string, w int) string {
 	bg := lipgloss.NewLayer(page)
 
+	compact := a.height < 20 || w < 60
+
 	// Adapt padding to terminal width.
 	padH := 3
 	if w < 50 {
@@ -274,21 +276,30 @@ func (a App) applyUpgradeConfirmOverlay(page string, w int) string {
 	}
 	pkgList := strings.Join(pkgLines, "\n")
 
-	warnStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary).Width(maxContentW)
-	explanation := warnStyle.Render(
-		"These packages are deferred by APT's phased-updates " +
-			"mechanism. They are held back to detect regressions " +
-			"before rolling out to all machines." +
-			"\n\n" +
-			"Forcing the upgrade may cause instability, especially " +
-			"for critical system packages (systemd, udev, etc.).")
+	var body string
+	if compact {
+		body = fmt.Sprintf(
+			"%s phased packages:\n\n%s",
+			countStyle.Render(fmt.Sprintf("%d", len(a.upgradePhasedPkgs))),
+			pkgList,
+		)
+	} else {
+		warnStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary).Width(maxContentW)
+		explanation := warnStyle.Render(
+			"These packages are deferred by APT's phased-updates " +
+				"mechanism. They are held back to detect regressions " +
+				"before rolling out to all machines." +
+				"\n\n" +
+				"Forcing the upgrade may cause instability, especially " +
+				"for critical system packages (systemd, udev, etc.).")
 
-	body := fmt.Sprintf(
-		"%s packages are phased:\n\n%s\n\n%s",
-		countStyle.Render(fmt.Sprintf("%d", len(a.upgradePhasedPkgs))),
-		pkgList,
-		explanation,
-	)
+		body = fmt.Sprintf(
+			"%s packages are phased:\n\n%s\n\n%s",
+			countStyle.Render(fmt.Sprintf("%d", len(a.upgradePhasedPkgs))),
+			pkgList,
+			explanation,
+		)
+	}
 
 	yKey := lipgloss.NewStyle().Bold(true).Foreground(ui.ColorWhite).Background(ui.ColorDanger).Padding(0, 1).Render("y")
 	sKey := lipgloss.NewStyle().Bold(true).Foreground(ui.ColorWhite).Background(ui.ColorSuccess).Padding(0, 1).Render("s")
@@ -296,15 +307,21 @@ func (a App) applyUpgradeConfirmOverlay(page string, w int) string {
 	hintText := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
 	hints := yKey + hintText.Render(" force all  ") + sKey + hintText.Render(" skip phased  ") + nKey + hintText.Render(" cancel")
 
-	content := lipgloss.JoinVertical(lipgloss.Center, title, "", body, "", hints)
+	var content string
+	content = lipgloss.JoinVertical(lipgloss.Center, title, "", body, "", hints)
 
+	padV := 1
+	if compact {
+		padV = 0
+	}
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(ui.ColorWarning).
-		Padding(1, padH).
+		Padding(padV, padH).
 		Align(lipgloss.Center).
 		Foreground(ui.ColorWhite).
 		MaxWidth(w).
+		MaxHeight(a.height).
 		Render(content)
 
 	boxW := lipgloss.Width(box)
@@ -420,6 +437,9 @@ func (a App) renderStacked(w int, tabBar string) string {
 	}
 	if a.removeConfirm {
 		page = a.applyRemoveConfirmOverlay(page, w)
+	}
+	if a.upgradeConfirm {
+		page = a.applyUpgradeConfirmOverlay(page, w)
 	}
 
 	return page
@@ -628,16 +648,6 @@ func (a App) renderVersionView(w int) string {
 	maxVisible := innerH - 4
 	if maxVisible < 3 {
 		maxVisible = 3
-	}
-
-	if a.loading {
-		content := fmt.Sprintf("\n  Loading versions for %s %s\n", a.versionPkg, a.spinner.View())
-		panel := renderTitledPanel("Version Selection", "", content, w, panelH)
-		gap := a.height - strings.Count(panel, "\n") - statusBarLines - 1
-		if gap < 0 {
-			gap = 0
-		}
-		return panel + strings.Repeat("\n", gap) + statusBarView
 	}
 
 	listContent := components.RenderVersionList(a.versionPkg, a.versionItems, a.versionIdx, a.versionOffset, maxVisible, w-4)

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -115,6 +115,7 @@ func (a App) applyImportConfirmOverlay(page string, w int) string {
 			Padding(1, 3).
 			Align(lipgloss.Center).
 			Foreground(ui.ColorWhite).
+			MaxWidth(w).
 			Render(detailContent)
 	} else {
 		title := lipgloss.NewStyle().
@@ -143,14 +144,23 @@ func (a App) applyImportConfirmOverlay(page string, w int) string {
 			Padding(1, 3).
 			Align(lipgloss.Center).
 			Foreground(ui.ColorWhite).
+			MaxWidth(w).
 			Render(content)
 	}
 
 	boxW := lipgloss.Width(box)
 	boxH := lipgloss.Height(box)
+	x := (w - boxW) / 2
+	if x < 0 {
+		x = 0
+	}
+	y := (a.height - boxH) / 2
+	if y < 0 {
+		y = 0
+	}
 	fg := lipgloss.NewLayer(box).
-		X((w - boxW) / 2).
-		Y((a.height - boxH) / 2).
+		X(x).
+		Y(y).
 		Z(1)
 	return lipgloss.NewCompositor(bg, fg).Render()
 }
@@ -201,19 +211,39 @@ func (a App) applyRemoveConfirmOverlay(page string, w int) string {
 		Padding(1, 3).
 		Align(lipgloss.Center).
 		Foreground(ui.ColorWhite).
+		MaxWidth(w).
 		Render(content)
 
 	boxW := lipgloss.Width(box)
 	boxH := lipgloss.Height(box)
+	x := (w - boxW) / 2
+	if x < 0 {
+		x = 0
+	}
+	y := (a.height - boxH) / 2
+	if y < 0 {
+		y = 0
+	}
 	fg := lipgloss.NewLayer(box).
-		X((w - boxW) / 2).
-		Y((a.height - boxH) / 2).
+		X(x).
+		Y(y).
 		Z(1)
 	return lipgloss.NewCompositor(bg, fg).Render()
 }
 
 func (a App) applyUpgradeConfirmOverlay(page string, w int) string {
 	bg := lipgloss.NewLayer(page)
+
+	// Adapt padding to terminal width.
+	padH := 3
+	if w < 50 {
+		padH = 1
+	}
+	chrome := 2 + padH*2 // border + horizontal padding
+	maxContentW := w - chrome
+	if maxContentW < 20 {
+		maxContentW = 20
+	}
 
 	title := lipgloss.NewStyle().
 		Bold(true).
@@ -244,12 +274,13 @@ func (a App) applyUpgradeConfirmOverlay(page string, w int) string {
 	}
 	pkgList := strings.Join(pkgLines, "\n")
 
-	warnStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
+	warnStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary).Width(maxContentW)
 	explanation := warnStyle.Render(
-		"These packages are deferred by APT's phased-updates\n" +
-			"mechanism. They are held back to detect regressions\n" +
-			"before rolling out to all machines.\n\n" +
-			"Forcing the upgrade may cause instability, especially\n" +
+		"These packages are deferred by APT's phased-updates " +
+			"mechanism. They are held back to detect regressions " +
+			"before rolling out to all machines." +
+			"\n\n" +
+			"Forcing the upgrade may cause instability, especially " +
 			"for critical system packages (systemd, udev, etc.).")
 
 	body := fmt.Sprintf(
@@ -270,16 +301,25 @@ func (a App) applyUpgradeConfirmOverlay(page string, w int) string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(ui.ColorWarning).
-		Padding(1, 3).
+		Padding(1, padH).
 		Align(lipgloss.Center).
 		Foreground(ui.ColorWhite).
+		MaxWidth(w).
 		Render(content)
 
 	boxW := lipgloss.Width(box)
 	boxH := lipgloss.Height(box)
+	x := (w - boxW) / 2
+	if x < 0 {
+		x = 0
+	}
+	y := (a.height - boxH) / 2
+	if y < 0 {
+		y = 0
+	}
 	fg := lipgloss.NewLayer(box).
-		X((w - boxW) / 2).
-		Y((a.height - boxH) / 2).
+		X(x).
+		Y(y).
 		Z(1)
 	return lipgloss.NewCompositor(bg, fg).Render()
 }

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -200,6 +200,134 @@ func ShowPackage(name string) (string, error) {
 	return out.String(), nil
 }
 
+// VersionInfo holds metadata about a specific version of a package.
+type VersionInfo struct {
+	Version   string
+	Installed bool
+	Origin    string // repository origin (e.g. "Ubuntu", archive URI)
+}
+
+// ListVersions returns all available versions for a package using apt-cache policy.
+func ListVersions(name string) ([]VersionInfo, error) {
+	cmd := exec.Command("apt-cache", "policy", name)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("apt-cache policy: %s", stderr.String())
+	}
+	return parsePolicyOutput(out.String()), nil
+}
+
+func parsePolicyOutput(output string) []VersionInfo {
+	var versions []VersionInfo
+	lines := strings.Split(output, "\n")
+
+	var installedVer string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "Installed: ") {
+			installedVer = strings.TrimPrefix(trimmed, "Installed: ")
+			if installedVer == "(none)" {
+				installedVer = ""
+			}
+		}
+	}
+
+	// Parse version table section.
+	// apt-cache policy output format:
+	//   Version table:
+	//    *** 8.5.0-2ubuntu10.9 500
+	//           500 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages
+	//           100 /var/lib/dpkg/status
+	//       8.5.0-2ubuntu10.4 500
+	//           500 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages
+	//
+	// Version lines start with "***" or a version string (contains dots/dashes).
+	// Origin lines start with a pure number (priority).
+	inTable := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "Version table:" {
+			inTable = true
+			continue
+		}
+		if !inTable || trimmed == "" {
+			continue
+		}
+
+		// Installed version line: "*** 8.5.0-2ubuntu10.9 500"
+		if strings.HasPrefix(trimmed, "***") {
+			parts := strings.Fields(trimmed)
+			if len(parts) >= 2 {
+				versions = append(versions, VersionInfo{
+					Version:   parts[1],
+					Installed: parts[1] == installedVer,
+				})
+			}
+			continue
+		}
+
+		parts := strings.Fields(trimmed)
+		if len(parts) == 0 {
+			continue
+		}
+
+		if isPureNumber(parts[0]) {
+			// Origin line like "500 http://archive.ubuntu.com/..."
+			if len(versions) > 0 && versions[len(versions)-1].Origin == "" && len(parts) >= 2 {
+				versions[len(versions)-1].Origin = strings.Join(parts[1:], " ")
+			}
+		} else {
+			// Version line like "8.5.0-2ubuntu10.4 500"
+			versions = append(versions, VersionInfo{
+				Version:   parts[0],
+				Installed: parts[0] == installedVer,
+			})
+		}
+	}
+	return versions
+}
+
+// isPureNumber returns true if s consists entirely of digits.
+func isPureNumber(s string) bool {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+// InstallVersionCmd returns a command to install a specific version of a package.
+func InstallVersionCmd(name, version string, recommends, suggests bool) *exec.Cmd {
+	args := []string{
+		"apt-get", "install", "-y",
+		"--allow-downgrades",
+		"-o", "Acquire::Queue-Mode=access",
+		"-o", "Acquire::Retries=3",
+		"-o", "Acquire::http::Pipeline-Depth=5",
+		"-o", "Acquire::Languages=none",
+	}
+	if recommends {
+		args = append(args, "--install-recommends")
+	} else {
+		args = append(args, "--no-install-recommends")
+	}
+	if suggests {
+		args = append(args, "--install-suggests")
+	} else {
+		args = append(args, "--no-install-suggests")
+	}
+	args = append(args, fmt.Sprintf("%s=%s", name, version))
+	c := platform.SudoCmd(args[0], args[1:]...)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	return c
+}
+
 func ListUpgradable() ([]model.Package, error) {
 	cmd := exec.Command("apt", "list", "--upgradable")
 	var out bytes.Buffer

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -290,14 +290,25 @@ func parsePolicyOutput(output string) []VersionInfo {
 	return versions
 }
 
-// isPureNumber returns true if s consists entirely of digits.
+// isPureNumber returns true if s is a valid integer priority (optionally
+// negative), as produced by apt-cache policy.
 func isPureNumber(s string) bool {
-	for _, c := range s {
+	if len(s) == 0 {
+		return false
+	}
+	start := 0
+	if s[0] == '-' {
+		if len(s) == 1 {
+			return false
+		}
+		start = 1
+	}
+	for _, c := range s[start:] {
 		if c < '0' || c > '9' {
 			return false
 		}
 	}
-	return len(s) > 0
+	return true
 }
 
 // InstallVersionCmd returns a command to install a specific version of a package.

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -23,14 +23,17 @@ const (
 	OpPurge      Operation = "purge"
 	OpUpgrade    Operation = "upgrade"
 	OpUpgradeAll Operation = "upgrade-all"
+	OpDowngrade  Operation = "downgrade"
 )
 
 type Transaction struct {
-	ID        int       `json:"id"`
-	Operation Operation `json:"operation"`
-	Packages  []string  `json:"packages"`
-	Timestamp time.Time `json:"timestamp"`
-	Success   bool      `json:"success"`
+	ID          int       `json:"id"`
+	Operation   Operation `json:"operation"`
+	Packages    []string  `json:"packages"`
+	Timestamp   time.Time `json:"timestamp"`
+	Success     bool      `json:"success"`
+	FromVersion string    `json:"from_version,omitempty"`
+	ToVersion   string    `json:"to_version,omitempty"`
 }
 
 type Store struct {
@@ -83,6 +86,26 @@ func (s *Store) Record(op Operation, packages []string, success bool) Transactio
 	return t
 }
 
+// RecordVersionChange records a version-specific operation (install version / downgrade).
+func (s *Store) RecordVersionChange(op Operation, packages []string, fromVersion, toVersion string, success bool) Transaction {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	t := Transaction{
+		ID:          s.NextID,
+		Operation:   op,
+		Packages:    packages,
+		Timestamp:   time.Now(),
+		Success:     success,
+		FromVersion: fromVersion,
+		ToVersion:   toVersion,
+	}
+	s.NextID++
+	s.Transactions = append(s.Transactions, t)
+	_ = s.save()
+	return t
+}
+
 func (s *Store) All() []Transaction {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -115,6 +138,8 @@ func UndoOperation(op Operation) Operation {
 		return OpInstall
 	case OpUpgrade, OpUpgradeAll:
 		return OpInstall
+	case OpDowngrade:
+		return OpDowngrade // revert to previous version
 	}
 	return OpInstall
 }

--- a/internal/model/keys.go
+++ b/internal/model/keys.go
@@ -41,6 +41,7 @@ type KeyMap struct {
 	Suggests     key.Binding
 	DetailScroll key.Binding
 	Tab          key.Binding
+	Version      key.Binding
 }
 
 var Keys = KeyMap{
@@ -194,6 +195,10 @@ var Keys = KeyMap{
 		key.WithKeys("tab"),
 		key.WithHelp("tab", "switch tab"),
 	),
+	Version: key.NewBinding(
+		key.WithKeys("v"),
+		key.WithHelp("v", "versions"),
+	),
 }
 
 func (k KeyMap) ShortHelp() []key.Binding {
@@ -204,7 +209,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.PageUp, k.PageDown, k.DetailScroll, k.Tab},
 		{k.Enter, k.Select, k.SelectAll, k.Search},
-		{k.Install, k.Remove, k.Upgrade, k.UpgradeAll, k.Purge, k.Hold, k.Pin},
+		{k.Install, k.Remove, k.Upgrade, k.UpgradeAll, k.Purge, k.Hold, k.Pin, k.Version},
 		{k.CleanupAll, k.ErrLogClear, k.AptUpdate, k.Fetch, k.Refresh},
 		{k.Export, k.ExportManual, k.Import, k.FileList, k.Layout, k.ThemeToggle, k.Recommends, k.Suggests},
 		{k.Help, k.Quit},

--- a/internal/ui/components/transactionlist.go
+++ b/internal/ui/components/transactionlist.go
@@ -139,6 +139,16 @@ func RenderTransactionDetail(tx history.Transaction, deps []string, width int, m
 	}
 	fmt.Fprintf(&b, "  %s %s %s\n", lbl.Render("Status"), sep.Render(":"), statusStyle.Render(status))
 
+	if tx.FromVersion != "" || tx.ToVersion != "" {
+		verStyle := lipgloss.NewStyle().Foreground(ui.ColorWarning).Bold(true)
+		if tx.FromVersion != "" {
+			fmt.Fprintf(&b, "  %s %s %s\n", lbl.Render("From Version"), sep.Render(":"), verStyle.Render(tx.FromVersion))
+		}
+		if tx.ToVersion != "" {
+			fmt.Fprintf(&b, "  %s %s %s\n", lbl.Render("To Version"), sep.Render(":"), verStyle.Render(tx.ToVersion))
+		}
+	}
+
 	pkgLabel := fmt.Sprintf("Packages (%d)", len(tx.Packages))
 	prefix := fmt.Sprintf("  %s %s ", lbl.Render(pkgLabel), sep.Render(":"))
 	indent := "  " + strings.Repeat(" ", 16) + "   "

--- a/internal/ui/components/versionlist.go
+++ b/internal/ui/components/versionlist.go
@@ -95,7 +95,7 @@ func RenderVersionList(pkgName string, versions []apt.VersionInfo, selected int,
 				if len(originStr) > maxOrigin {
 					originStr = originStr[:maxOrigin-1] + "…"
 				}
-				verPad := colVer - len(verStr) - len(marker)
+				verPad := colVer - lipgloss.Width(verStr) - lipgloss.Width(marker)
 				if verPad < 0 {
 					verPad = 0
 				}
@@ -123,7 +123,7 @@ func RenderVersionList(pkgName string, versions []apt.VersionInfo, selected int,
 				if len(originStr) > maxOrigin {
 					originStr = originStr[:maxOrigin-1] + "…"
 				}
-				verPad := colVer - len(verStr) - len(marker)
+				verPad := colVer - lipgloss.Width(verStr) - lipgloss.Width(marker)
 				if verPad < 0 {
 					verPad = 0
 				}

--- a/internal/ui/components/versionlist.go
+++ b/internal/ui/components/versionlist.go
@@ -1,0 +1,146 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/mexirica/aptui/internal/apt"
+	"github.com/mexirica/aptui/internal/ui"
+)
+
+// RenderVersionList renders the version selection overlay for a package.
+func RenderVersionList(pkgName string, versions []apt.VersionInfo, selected int, offset int, maxVisible int, width int) string {
+	if width < 20 {
+		width = 20
+	}
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.ColorColumnHeader)
+	verStyle := lipgloss.NewStyle().Foreground(ui.ColorWhite)
+	installedStyle := lipgloss.NewStyle().Foreground(ui.ColorSuccess).Bold(true)
+	originStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
+	cursorSt := lipgloss.NewStyle().Foreground(ui.ColorPrimary).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
+
+	if len(versions) == 0 {
+		return lipgloss.NewStyle().Foreground(ui.ColorSecondary).
+			Render("\n  No versions available in configured repositories.\n" +
+				"  Tip: add PPAs or use Ubuntu Snapshot Service for older versions.\n")
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("  %s %s\n",
+		headerStyle.Render("Select version for:"),
+		lipgloss.NewStyle().Foreground(ui.ColorPrimary).Bold(true).Render(pkgName)))
+	b.WriteString(fmt.Sprintf("  %s\n\n",
+		dimStyle.Render("(enter to install, esc to cancel)")))
+
+	// Column widths - responsive
+	showSource := width > 60
+	colVer := width - 6 // cursor(4) + padding(2)
+	if showSource {
+		colVer = width * 55 / 100 // 55% for version
+		if colVer < 25 {
+			colVer = 25
+		}
+	}
+
+	// Header
+	if showSource {
+		padding := colVer - 7
+		if padding < 1 {
+			padding = 1
+		}
+		header := fmt.Sprintf("    %s%s%s",
+			headerStyle.Render("Version"),
+			strings.Repeat(" ", padding),
+			headerStyle.Render("Source"))
+		b.WriteString(header + "\n")
+	} else {
+		b.WriteString("    " + headerStyle.Render("Version") + "\n")
+	}
+
+	end := offset + maxVisible
+	if end > len(versions) {
+		end = len(versions)
+	}
+
+	for i := offset; i < end; i++ {
+		v := versions[i]
+
+		verStr := v.Version
+		maxVer := colVer - 4
+		if maxVer < 10 {
+			maxVer = 10
+		}
+		if len(verStr) > maxVer {
+			verStr = verStr[:maxVer-1] + "…"
+		}
+
+		style := verStyle
+		marker := "  "
+		if v.Installed {
+			style = installedStyle
+			marker = "● "
+		}
+
+		if i == selected {
+			cursor := cursorSt.Render("▌ ")
+			if showSource {
+				originStr := v.Origin
+				maxOrigin := width - colVer - 8
+				if maxOrigin < 1 {
+					maxOrigin = 1
+				}
+				if len(originStr) > maxOrigin {
+					originStr = originStr[:maxOrigin-1] + "…"
+				}
+				verPad := colVer - len(verStr) - len(marker)
+				if verPad < 0 {
+					verPad = 0
+				}
+				row := fmt.Sprintf("  %s%s%s%s%s\n",
+					cursor,
+					style.Render(marker),
+					style.Render(verStr),
+					strings.Repeat(" ", verPad),
+					originStyle.Render(originStr))
+				b.WriteString(row)
+			} else {
+				row := fmt.Sprintf("  %s%s%s\n",
+					cursor,
+					style.Render(marker),
+					style.Render(verStr))
+				b.WriteString(row)
+			}
+		} else {
+			if showSource {
+				originStr := v.Origin
+				maxOrigin := width - colVer - 8
+				if maxOrigin < 1 {
+					maxOrigin = 1
+				}
+				if len(originStr) > maxOrigin {
+					originStr = originStr[:maxOrigin-1] + "…"
+				}
+				verPad := colVer - len(verStr) - len(marker)
+				if verPad < 0 {
+					verPad = 0
+				}
+				row := fmt.Sprintf("    %s%s%s%s\n",
+					dimStyle.Render(marker),
+					dimStyle.Render(verStr),
+					strings.Repeat(" ", verPad),
+					dimStyle.Render(originStr))
+				b.WriteString(row)
+			} else {
+				row := fmt.Sprintf("    %s%s\n",
+					dimStyle.Render(marker),
+					dimStyle.Render(verStr))
+				b.WriteString(row)
+			}
+		}
+	}
+
+	return b.String()
+}


### PR DESCRIPTION
Fix #110.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a version selector (`v`) that lets users browse all available versions of a package via `apt-cache policy` and install any of them, including downgrades. It also wires up undo/redo for version-change operations, captures stderr from apt commands for better error messages, and adds responsive-dialog improvements for small terminals.

- **Version selection & downgrade**: `keypress_version.go` and `versionlist.go` implement the overlay UI; `apt/client.go` adds `ListVersions`/`InstallVersionCmd`; `history.go` gains `OpDowngrade` and `FromVersion`/`ToVersion` fields so undo/redo can restore the exact prior version.
- **Stderr capture**: `execProcessWithStderr` wraps all `tea.ExecProcess` calls with an `io.MultiWriter` to capture apt's stderr, enabling `friendlyError`/`extractAptError` to surface the most relevant error line rather than a generic exit code.
- **Mouse guard & responsive dialogs**: `onMouseClick` now blocks events while the version overlay is open; overlay positioning clamps `x`/`y` to avoid negative coordinates on small terminals.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new version-selector and downgrade flows work correctly for all reachable code paths.

The two findings are both in edge cases that cannot be reached through normal UI interactions: one is unreachable dead code (a condition arm whose string value is never produced), and the other requires a malformed history entry with multiple packages on a downgrade record, which the current code cannot create. Core paths — version loading, install, downgrade detection, undo/redo with version info, stderr capture, and mouse guard — are all correctly implemented.

No files require special attention; internal/app/keypress_transaction.go and internal/app/update.go have minor edge-case gaps but they do not affect normal operation.

<sub>Reviews (8): Last reviewed commit: ["feat: update padding calculation in vers..."](https://github.com/mexirica/aptui/commit/17fc0eee444bece05e2c684ee754105092d8e3ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31158468)</sub>

<!-- /greptile_comment -->