### PR TITLE
Feat: update applyFilter to preserve selection across various components

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -56,7 +56,7 @@ func TestApplyFilterAll(t *testing.T) {
 	}
 	a.activeTab = tabAll
 	a.filterQuery = ""
-	a.applyFilter()
+	a.applyFilter(true)
 
 	if len(a.filtered) != 3 {
 		t.Errorf("expected 3 packages on All tab, got %d", len(a.filtered))
@@ -72,7 +72,7 @@ func TestApplyFilterInstalledTab(t *testing.T) {
 	}
 	a.activeTab = tabInstalled
 	a.filterQuery = ""
-	a.applyFilter()
+	a.applyFilter(true)
 
 	if len(a.filtered) != 2 {
 		t.Errorf("expected 2 installed packages, got %d", len(a.filtered))
@@ -93,7 +93,7 @@ func TestApplyFilterUpgradableTab(t *testing.T) {
 	}
 	a.activeTab = tabUpgradable
 	a.filterQuery = ""
-	a.applyFilter()
+	a.applyFilter(true)
 
 	if len(a.filtered) != 1 {
 		t.Errorf("expected 1 upgradable package, got %d", len(a.filtered))
@@ -113,7 +113,7 @@ func TestApplyFilterFuzzySearch(t *testing.T) {
 	}
 	a.activeTab = tabAll
 	a.filterQuery = "vim"
-	a.applyFilter()
+	a.applyFilter(true)
 
 	if len(a.filtered) == 0 {
 		t.Error("expected at least 1 result for 'vim'")
@@ -130,7 +130,7 @@ func TestApplyFilterResetsSelection(t *testing.T) {
 	}
 	a.selectedIdx = 2
 	a.scrollOffset = 1
-	a.applyFilter()
+	a.applyFilter(true)
 
 	if a.selectedIdx != 0 {
 		t.Errorf("expected selectedIdx reset to 0, got %d", a.selectedIdx)
@@ -288,7 +288,7 @@ func TestTabSwitching(t *testing.T) {
 		{Name: "git", Installed: true, Upgradable: true},
 		{Name: "curl", Installed: false},
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	if a.activeTab != tabAll {
 		t.Errorf("expected tabAll initially, got %d", a.activeTab)
@@ -363,7 +363,7 @@ func TestSearchMode(t *testing.T) {
 	a.allPackages = []model.Package{
 		{Name: "vim"}, {Name: "git"}, {Name: "curl"},
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	// Enter search mode
 	m, _ := a.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
@@ -404,7 +404,7 @@ func TestViewNotEmpty(t *testing.T) {
 	a.allPackages = []model.Package{
 		{Name: "vim", Installed: true, Version: "8.2"},
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	v := a.View()
 	if v.Content == "" {
@@ -995,7 +995,7 @@ func TestSearchBarYPositive(t *testing.T) {
 	a.allPackages = []model.Package{
 		{Name: "vim", Installed: true},
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 	y := a.searchBarY()
 	if y <= 0 || y >= a.height {
 		t.Errorf("searchBarY=%d should be between 1 and %d", y, a.height-1)
@@ -1065,7 +1065,7 @@ func TestHoldListMsg(t *testing.T) {
 		{Name: "curl", Installed: false},
 	}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 
 	msg := holdListMsg{names: []string{"vim"}, err: nil}
 	m, _ := a.Update(msg)
@@ -1102,7 +1102,7 @@ func TestHoldSelectedPackage(t *testing.T) {
 		{Name: "vim", Installed: true},
 	}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	a.heldSet = make(map[string]bool)
 
@@ -1123,7 +1123,7 @@ func TestUnholdSelectedPackage(t *testing.T) {
 		{Name: "vim", Installed: true, Held: true},
 	}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	a.heldSet = map[string]bool{"vim": true}
 
@@ -1144,7 +1144,7 @@ func TestHoldNotInstalledPackage(t *testing.T) {
 		{Name: "vim", Installed: false},
 	}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	a.heldSet = make(map[string]bool)
 
@@ -1185,7 +1185,7 @@ func TestUpgradeBlockedForHeldPackage(t *testing.T) {
 		{Name: "vim", Installed: true, Upgradable: true, Held: true, Version: "8.2", NewVersion: "9.0"},
 	}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	a.heldSet = map[string]bool{"vim": true}
 
@@ -1210,7 +1210,7 @@ func TestUpgradeAllSkipsHeldPackages(t *testing.T) {
 		{Name: "git", Installed: true, Upgradable: true, Version: "2.34", NewVersion: "2.40"},
 	}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.upgradableMap = map[string]model.Package{
 		"vim": {Name: "vim", NewVersion: "9.0"},
 		"git": {Name: "git", NewVersion: "2.40"},
@@ -1442,7 +1442,7 @@ func TestSearchBarYSideBySide(t *testing.T) {
 	a := newTestApp()
 	a.sideBySide = true
 	a.allPackages = []model.Package{{Name: "vim", Installed: true}}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	y := a.searchBarY()
 	// Info panel is now above the main panels, directly after tabBar + gap.
@@ -1575,7 +1575,7 @@ func TestReposTabKeypress(t *testing.T) {
 func TestTKeyDoesNotOpenTransactionView(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim"}}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	m, _ := a.Update(tea.KeyPressMsg{Code: 't', Text: "t"})
 	app := m.(App)
@@ -1588,7 +1588,7 @@ func TestTKeyDoesNotOpenTransactionView(t *testing.T) {
 func TestPKeyDoesNotOpenPPAView(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim"}}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	m, _ := a.Update(tea.KeyPressMsg{Code: 'P', Text: "P"})
 	app := m.(App)
@@ -1631,7 +1631,7 @@ func TestRenderSideBySideNotEmpty(t *testing.T) {
 		{Name: "vim", Installed: true},
 		{Name: "git", Installed: false},
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	tabBar := a.renderTabBar()
 	out := a.renderSideBySide(a.width, tabBar)
@@ -1664,7 +1664,7 @@ func TestRenderStackedNotEmpty(t *testing.T) {
 		{Name: "vim", Installed: true},
 		{Name: "git", Installed: false},
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	tabBar := a.renderTabBar()
 	out := a.renderStacked(a.width, tabBar)
@@ -1701,7 +1701,7 @@ func TestViewSideBySideMode(t *testing.T) {
 	a := newTestApp()
 	a.sideBySide = true
 	a.allPackages = []model.Package{{Name: "vim", Installed: true}}
-	a.applyFilter()
+	a.applyFilter(true)
 
 	view := a.View()
 	if view.Content == "" {
@@ -3427,7 +3427,7 @@ func TestView_SideBySide(t *testing.T) {
 	a.sideBySide = true
 	a.allPackages = []model.Package{{Name: "vim", Installed: true}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	v := a.View()
 	if v.Content == "" {
 		t.Error("View should render content")
@@ -3441,7 +3441,7 @@ func TestView_Stacked(t *testing.T) {
 	a.sideBySide = false
 	a.allPackages = []model.Package{{Name: "vim", Installed: true}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	v := a.View()
 	if v.Content == "" {
 		t.Error("View should render content")
@@ -4183,7 +4183,7 @@ func TestSubmitSearch_EmptyQuery(t *testing.T) {
 	a.searchInput.SetValue("")
 	a.allPackages = []model.Package{{Name: "vim", Installed: true}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	m, _ := a.submitSearch()
 	result := m.(App)
 	if result.searching {
@@ -4203,7 +4203,7 @@ func TestSubmitSearch_WithResults(t *testing.T) {
 	}
 	a.rebuildIndex()
 	a.filterQuery = "vim"
-	a.applyFilter()
+	a.applyFilter(true)
 	a.searchInput.SetValue("vim")
 	m, _ := a.submitSearch()
 	result := m.(App)
@@ -4218,7 +4218,7 @@ func TestCancelSearch(t *testing.T) {
 	a.filterQueryBeforeEdit = "old-query"
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	m, _ := a.cancelSearch()
 	result := m.(App)
 	if result.searching {
@@ -4237,7 +4237,7 @@ func TestUpdateSearchFilter(t *testing.T) {
 		{Name: "git", Installed: false},
 	}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	msg := tea.KeyPressMsg{Code: 'v', Text: "v"}
 	m, _ := a.updateSearchFilter(msg)
 	result := m.(App)
@@ -4252,7 +4252,7 @@ func TestOnSearchKeypress_Enter(t *testing.T) {
 	a.searchInput.SetValue("")
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
 	m, _ := a.onSearchKeypress(msg)
 	result := m.(App)
@@ -4266,7 +4266,7 @@ func TestOnSearchKeypress_Esc(t *testing.T) {
 	a.searching = true
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	msg := tea.KeyPressMsg{Code: tea.KeyEsc}
 	m, _ := a.onSearchKeypress(msg)
 	result := m.(App)
@@ -4400,7 +4400,7 @@ func TestClearFilterOrSearch_WithFilter(t *testing.T) {
 	a.filterQuery = "vim"
 	a.allPackages = []model.Package{{Name: "vim"}, {Name: "git"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	m, _ := a.clearFilterOrSearch()
 	result := m.(App)
 	if result.filterQuery != "" {
@@ -4472,7 +4472,7 @@ func TestDispatchNavigation_Down(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "a"}, {Name: "b"}, {Name: "c"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	msg := tea.KeyPressMsg{Code: 0, Text: "j"}
 	m, _, handled := a.dispatchNavigation(msg)
@@ -4489,7 +4489,7 @@ func TestDispatchNavigation_Up(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "a"}, {Name: "b"}, {Name: "c"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 2
 	msg := tea.KeyPressMsg{Code: 0, Text: "k"}
 	m, _, handled := a.dispatchNavigation(msg)
@@ -4515,7 +4515,7 @@ func TestDispatchSelection_Space(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	msg := tea.KeyPressMsg{Code: 0, Text: "space"}
 	m, _, handled := a.dispatchSelection(msg)
@@ -4532,7 +4532,7 @@ func TestToggleSelectAll(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim"}, {Name: "git"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selected = make(map[string]bool)
 
 	// Select all
@@ -4554,7 +4554,7 @@ func TestDispatchPackageAction_Install(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim", Installed: false}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	msg := tea.KeyPressMsg{Code: 0, Text: "i"}
 	m, cmd, handled := a.dispatchPackageAction(msg)
@@ -4577,7 +4577,7 @@ func TestInstallSelectedPackages_AlreadyInstalled(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim", Installed: true}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	m, _ := a.installSelectedPackages()
 	result := m.(App)
@@ -4590,7 +4590,7 @@ func TestRemoveSelectedPackages_NotInstalled(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim", Installed: false}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	m, _ := a.removeSelectedPackages()
 	result := m.(App)
@@ -4603,7 +4603,7 @@ func TestRemoveSelectedPackages_Essential(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "base-files", Installed: true, Essential: true}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	a.essentialSet = map[string]bool{"base-files": true}
 	m, _ := a.removeSelectedPackages()
@@ -4617,7 +4617,7 @@ func TestRemoveSelectedPackages_ShowsConfirm(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim", Installed: true}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	a.essentialSet = make(map[string]bool)
 	m, _ := a.removeSelectedPackages()
@@ -4634,7 +4634,7 @@ func TestUpgradeSelectedPackages(t *testing.T) {
 	a := newTestApp()
 	a.allPackages = []model.Package{{Name: "vim", Installed: true, Upgradable: true}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	a.upgradableMap = map[string]model.Package{"vim": {Name: "vim", Upgradable: true}}
 	m, cmd := a.upgradeSelectedPackages()
@@ -4658,7 +4658,7 @@ func TestScrollPackagesDown(t *testing.T) {
 	}
 	a.allPackages = pkgs
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	m, _ := a.scrollPackagesDown()
 	result := m.(App)
@@ -4675,7 +4675,7 @@ func TestScrollPackagesUp(t *testing.T) {
 	}
 	a.allPackages = pkgs
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 50
 	m, _ := a.scrollPackagesUp()
 	result := m.(App)
@@ -4806,7 +4806,7 @@ func TestView_ImportConfirmOverlay(t *testing.T) {
 	a.importFromPath = "/tmp/packages.txt"
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	v := a.View()
 	if v.Content == "" {
 		t.Error("view with import overlay should produce content")
@@ -4821,7 +4821,7 @@ func TestView_RemoveConfirmOverlay(t *testing.T) {
 	a.removeCancelFocus = true
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	v := a.View()
 	if v.Content == "" {
 		t.Error("view with remove overlay should produce content")
@@ -4850,7 +4850,7 @@ func TestView_FileListActive(t *testing.T) {
 	a.fileListOffset = 0
 	a.allPackages = []model.Package{{Name: "vim", Installed: true}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	v := a.View()
 	if v.Content == "" {
 		t.Error("view with file list active should produce content")
@@ -4862,7 +4862,7 @@ func TestView_Loading(t *testing.T) {
 	a.loading = true
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	v := a.View()
 	if v.Content == "" {
 		t.Error("loading view should produce content")
@@ -4874,7 +4874,7 @@ func TestView_Searching(t *testing.T) {
 	a.searching = true
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	v := a.View()
 	if v.Content == "" {
 		t.Error("view while searching should produce content")
@@ -4886,7 +4886,7 @@ func TestView_ImportingPath(t *testing.T) {
 	a.importingPath = true
 	a.allPackages = []model.Package{{Name: "vim"}}
 	a.rebuildIndex()
-	a.applyFilter()
+	a.applyFilter(true)
 	v := a.View()
 	if v.Content == "" {
 		t.Error("view while importing path should produce content")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -130,7 +130,7 @@ func TestApplyFilterResetsSelection(t *testing.T) {
 	}
 	a.selectedIdx = 2
 	a.scrollOffset = 1
-	a.applyFilter(true)
+	a.applyFilter(false)
 
 	if a.selectedIdx != 0 {
 		t.Errorf("expected selectedIdx reset to 0, got %d", a.selectedIdx)

--- a/internal/app/bench_test.go
+++ b/internal/app/bench_test.go
@@ -75,7 +75,7 @@ func BenchmarkApplyFilterNoFilter(b *testing.B) {
 	a := buildBenchApp(b)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.applyFilter()
+		a.applyFilter(true)
 	}
 }
 
@@ -85,7 +85,7 @@ func BenchmarkApplyFilterName(b *testing.B) {
 	a.filterQuery = "name:vim"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.applyFilter()
+		a.applyFilter(true)
 	}
 }
 
@@ -96,7 +96,7 @@ func BenchmarkApplyFilterSection(b *testing.B) {
 	a.filterQuery = "section:utils"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.applyFilter()
+		a.applyFilter(true)
 	}
 }
 
@@ -106,7 +106,7 @@ func BenchmarkApplyFilterArch(b *testing.B) {
 	a.filterQuery = "arch:amd64"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.applyFilter()
+		a.applyFilter(true)
 	}
 }
 
@@ -116,7 +116,7 @@ func BenchmarkApplyFilterSize(b *testing.B) {
 	a.filterQuery = "size>10MB"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.applyFilter()
+		a.applyFilter(true)
 	}
 }
 
@@ -126,7 +126,7 @@ func BenchmarkApplyFilterCombined(b *testing.B) {
 	a.filterQuery = "section:utils arch:amd64 size>1MB"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.applyFilter()
+		a.applyFilter(true)
 	}
 }
 
@@ -136,7 +136,7 @@ func BenchmarkApplyFilterInstalled(b *testing.B) {
 	a.filterQuery = "installed"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.applyFilter()
+		a.applyFilter(true)
 	}
 }
 
@@ -146,7 +146,7 @@ func BenchmarkApplyFilterSortBySize(b *testing.B) {
 	a.filterQuery = "installed order:size:desc"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		a.applyFilter()
+		a.applyFilter(true)
 	}
 }
 

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -127,7 +127,7 @@ func (a *App) activateTab() tea.Cmd {
 		a.status = "Loading repositories..."
 		return tea.Batch(a.spinner.Tick, listPPAsCmd())
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 	cmd := a.updateSelectionCmd()
 	a.status = fmt.Sprintf("%d packages ", len(a.filtered))
 	return cmd
@@ -135,7 +135,15 @@ func (a *App) activateTab() tea.Cmd {
 
 // applyFilter rebuilds the filtered list from allPackages based on active tab,
 // advanced filter, and search query. Uses fuzzy scoring when a search query is active.
-func (a *App) applyFilter() {
+// When preserveSelection is true the cursor is kept on the same package after the
+// rebuild (used when the query itself did not change, e.g. the user clicked a row
+// while the search input was active). Pass false to reset the cursor to the top.
+func (a *App) applyFilter(preserveSelection bool) {
+	var selectedName string
+	if preserveSelection && a.selectedIdx >= 0 && a.selectedIdx < len(a.filtered) {
+		selectedName = a.filtered[a.selectedIdx].Name
+	}
+
 	var source []model.Package
 	switch a.activeTab {
 	case tabInstalled:
@@ -273,8 +281,19 @@ func (a *App) applyFilter() {
 		})
 	}
 
+	// Restore cursor to the previously selected package, or reset to 0 if it
+	// is no longer in the filtered list.
 	a.selectedIdx = 0
 	a.scrollOffset = 0
+	if selectedName != "" {
+		for i, p := range a.filtered {
+			if p.Name == selectedName {
+				a.selectedIdx = i
+				a.adjustPackageScroll()
+				break
+			}
+		}
+	}
 }
 
 // effectiveSortInfo returns the active sort state, preferring click-based sort
@@ -366,7 +385,7 @@ func (a *App) applyOptimisticUpdate(op string, pkgs []string) {
 		a.autoremovable = nil
 		a.autoremovableSet = make(map[string]bool)
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 }
 
 // enrichedDetailInfo prepends status and manual-install lines to raw

--- a/internal/app/keypress.go
+++ b/internal/app/keypress.go
@@ -161,8 +161,6 @@ func (a App) clearFilterOrSearch() (tea.Model, tea.Cmd) {
 	}
 	a.filterQuery = ""
 	a.applyFilter(false)
-	a.selectedIdx = 0
-	a.scrollOffset = 0
 	a.status = fmt.Sprintf("%d packages ", len(a.filtered))
 	return a, a.updateSelectionCmd()
 }

--- a/internal/app/keypress.go
+++ b/internal/app/keypress.go
@@ -160,7 +160,7 @@ func (a App) clearFilterOrSearch() (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 	a.filterQuery = ""
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selectedIdx = 0
 	a.scrollOffset = 0
 	a.status = fmt.Sprintf("%d packages ", len(a.filtered))

--- a/internal/app/keypress.go
+++ b/internal/app/keypress.go
@@ -160,7 +160,7 @@ func (a App) clearFilterOrSearch() (tea.Model, tea.Cmd) {
 		return a, nil
 	}
 	a.filterQuery = ""
-	a.applyFilter(true)
+	a.applyFilter(false)
 	a.selectedIdx = 0
 	a.scrollOffset = 0
 	a.status = fmt.Sprintf("%d packages ", len(a.filtered))

--- a/internal/app/keypress_actions.go
+++ b/internal/app/keypress_actions.go
@@ -52,9 +52,6 @@ func (a App) scrollPackagesDown() (tea.Model, tea.Cmd) {
 	if a.selectedIdx >= len(a.filtered) {
 		a.selectedIdx = len(a.filtered) - 1
 	}
-	if a.selectedIdx < 0 {
-		a.selectedIdx = 0
-	}
 	a.detailScrollOffset = 0
 	a.adjustPackageScroll()
 	return a, a.updateSelectionCmd()

--- a/internal/app/keypress_actions.go
+++ b/internal/app/keypress_actions.go
@@ -450,7 +450,7 @@ func (a App) togglePinPackages() (tea.Model, tea.Cmd) {
 		}
 	}
 
-	a.applyFilter()
+	a.applyFilter(true)
 	a.selected = make(map[string]bool)
 
 	// Restore cursor to the same package after reorder

--- a/internal/app/keypress_actions.go
+++ b/internal/app/keypress_actions.go
@@ -453,15 +453,6 @@ func (a App) togglePinPackages() (tea.Model, tea.Cmd) {
 	a.applyFilter(true)
 	a.selected = make(map[string]bool)
 
-	// Restore cursor to the same package after reorder
-	for i, p := range a.filtered {
-		if p.Name == currentName {
-			a.selectedIdx = i
-			a.adjustPackageScroll()
-			break
-		}
-	}
-
 	if pinned > 0 && unpinned > 0 {
 		a.status = fmt.Sprintf("Pinned %d, unpinned %d packages", pinned, unpinned)
 	} else if pinned > 0 {

--- a/internal/app/keypress_actions.go
+++ b/internal/app/keypress_actions.go
@@ -52,6 +52,9 @@ func (a App) scrollPackagesDown() (tea.Model, tea.Cmd) {
 	if a.selectedIdx >= len(a.filtered) {
 		a.selectedIdx = len(a.filtered) - 1
 	}
+	if a.selectedIdx < 0 {
+		a.selectedIdx = 0
+	}
 	a.detailScrollOffset = 0
 	a.adjustPackageScroll()
 	return a, a.updateSelectionCmd()

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -194,7 +194,7 @@ func (a App) onHeaderClick(x int) (tea.Model, tea.Cmd) {
 		a.sortDesc = false
 	}
 
-	a.applyFilter()
+	a.applyFilter(true)
 	return a, a.updateSelectionCmd()
 }
 

--- a/internal/app/keypress_search.go
+++ b/internal/app/keypress_search.go
@@ -26,10 +26,14 @@ func (a App) forwardToActiveInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case a.searching:
 		var cmd tea.Cmd
 		a.searchInput, cmd = a.searchInput.Update(msg)
-		a.filterQuery = a.searchInput.Value()
-		a.applyFilter()
-		a.status = fmt.Sprintf("%d matching ", len(a.filtered))
-		return a, tea.Batch(cmd, a.updateSelectionCmd())
+		newQuery := a.searchInput.Value()
+		if newQuery != a.filterQuery {
+			a.filterQuery = newQuery
+			a.applyFilter(false)
+			a.status = fmt.Sprintf("%d matching ", len(a.filtered))
+			return a, tea.Batch(cmd, a.updateSelectionCmd())
+		}
+		return a, cmd
 	case a.importingPath:
 		var cmd tea.Cmd
 		a.importInput, cmd = a.importInput.Update(msg)
@@ -48,7 +52,7 @@ func (a App) submitSearch() (tea.Model, tea.Cmd) {
 	a.searchInput.Blur()
 	a.filterQuery = query
 	if query == "" {
-		a.applyFilter()
+		a.applyFilter(true)
 		a.status = fmt.Sprintf("%d packages ", len(a.filtered))
 		return a, a.updateSelectionCmd()
 	}
@@ -71,7 +75,7 @@ func (a App) cancelSearch() (tea.Model, tea.Cmd) {
 	a.searching = false
 	a.searchInput.Blur()
 	a.filterQuery = a.filterQueryBeforeEdit
-	a.applyFilter()
+	a.applyFilter(true)
 	a.status = fmt.Sprintf("%d packages ", len(a.filtered))
 	return a, a.updateSelectionCmd()
 }
@@ -80,7 +84,7 @@ func (a App) updateSearchFilter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	a.searchInput, cmd = a.searchInput.Update(msg)
 	a.filterQuery = a.searchInput.Value()
-	a.applyFilter()
+	a.applyFilter(false)
 	a.status = fmt.Sprintf("%d matching ", len(a.filtered))
 	return a, tea.Batch(cmd, a.updateSelectionCmd())
 }

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -220,7 +220,7 @@ func (a App) onAllPackagesLoaded(msg allPackagesMsg) (tea.Model, tea.Cmd) {
 	a.installedCount = len(msg.installed)
 	firstLoad := !a.allNamesLoaded
 	a.allNamesLoaded = true
-	a.applyFilter()
+	a.applyFilter(true)
 	upgCount := len(msg.upgradable)
 	defaultStatus := fmt.Sprintf("%d packages (%d installed, %d upgradable) ",
 		len(a.allPackages), a.installedCount, upgCount)
@@ -296,7 +296,7 @@ func (a App) onSilentUpdateDone(msg silentUpdateDoneMsg) (tea.Model, tea.Cmd) {
 			a.allPackages[idx].SecurityUpdate = up.SecurityUpdate
 		}
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 	upgCount := len(msg.upgradable)
 	defaultStatus := fmt.Sprintf("%d packages (%d installed, %d upgradable) ",
 		len(a.allPackages), a.installedCount, upgCount)
@@ -651,7 +651,7 @@ func (a App) onAutoremovableLoaded(msg autoremovableMsg) (tea.Model, tea.Cmd) {
 		a.autoremovable = nil
 		a.autoremovableSet = make(map[string]bool)
 		if a.activeTab == tabCleanup {
-			a.applyFilter()
+			a.applyFilter(true)
 		}
 		return a, nil
 	}
@@ -661,7 +661,7 @@ func (a App) onAutoremovableLoaded(msg autoremovableMsg) (tea.Model, tea.Cmd) {
 		a.autoremovableSet[name] = true
 	}
 	if a.activeTab == tabCleanup {
-		a.applyFilter()
+		a.applyFilter(true)
 		if time.Since(a.statusLock) >= 2*time.Second {
 			a.status = fmt.Sprintf("%d packages ", len(a.filtered))
 		} else {
@@ -684,7 +684,7 @@ func (a App) onHeldListLoaded(msg holdListMsg) (tea.Model, tea.Cmd) {
 	for i := range a.allPackages {
 		a.allPackages[i].Held = a.heldSet[a.allPackages[i].Name]
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 	return a, nil
 }
 
@@ -716,7 +716,7 @@ func (a App) onHoldFinished(msg holdFinishedMsg) (tea.Model, tea.Cmd) {
 	for i := range a.allPackages {
 		a.allPackages[i].Held = a.heldSet[a.allPackages[i].Name]
 	}
-	a.applyFilter()
+	a.applyFilter(true)
 	a.status = ui.SuccessStyle.Render(fmt.Sprintf("✔ %s completed!", msg.op))
 	a.statusLock = time.Now()
 	return a, clearStatusAfter(2 * time.Second)


### PR DESCRIPTION
Fix #114.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `applyFilter` to accept a `preserveSelection bool` parameter, centralising cursor-restore logic that was previously duplicated at call sites (e.g., `togglePinPackages`). When `true`, the selected package name is snapshotted before the list is rebuilt and the cursor is walked back to the same row afterwards; when `false`, cursor and scroll reset to zero as before.

- **`helpers.go`**: Core implementation — snapshot, rebuild, linear-scan restore, `adjustPackageScroll()` call; guarded against a negative or out-of-range `selectedIdx`.
- **`keypress_search.go`**: `forwardToActiveInput` gains an early-return optimisation that skips `applyFilter` and `updateSelectionCmd` when the typed query hasn't actually changed; `updateSearchFilter` / `cancelSearch` use `false` and `true` respectively.
- **`keypress.go` / `keypress_actions.go` / `keypress_mouse.go` / `update.go`**: All remaining call sites updated to pass the semantically correct boolean; redundant inline restore loops removed.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it centralises existing cursor-restore logic with no observable behaviour regressions on the paths covered by tests.

All call sites are updated consistently, both reset (false) and preserve (true) paths are exercised by dedicated tests, and the new code is guarded against out-of-range indices. Background-refresh and tab-switch paths correctly keep true so the cursor survives async reloads.

No files require special attention.

<sub>Reviews (5): Last reviewed commit: ["Fix: update applyFilter call to prevent ..."](https://github.com/mexirica/aptui/commit/4dcc1130f349b57895433c516b4abfc3645d826a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31489466)</sub>

<!-- /greptile_comment -->