### PR TITLE
Feat: implement inSearchBox function and enhance mouse click handling

### DIFF
--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -498,6 +498,13 @@ func (a App) searchBarY() int {
 	return 3
 }
 
+// inSearchBox reports whether the given Y coordinate falls within the
+// search/status info panel (border included).
+func (a App) inSearchBox(y int) bool {
+	top := a.searchBarY() - 1 // top border row
+	return y >= top && y < top+infoRowH
+}
+
 // Layout constants and helpers.
 const (
 	infoRowH     = 5  // 3 inner lines + 2 border lines

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -17,15 +17,12 @@ const (
 )
 
 func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
-	// Block mouse interactions while a modal dialog is open.
 	if a.importConfirm || a.removeConfirm || a.upgradeConfirm || a.versionView {
 		return a, nil
 	}
 	a.exportConfirm = false
 	m := msg.Mouse()
 
-	// If in search mode, clicking outside the search bar submits the search
-	// (like pressing Enter). Clicking on the search input row keeps search active.
 	if a.searching {
 		if _, isClick := msg.(tea.MouseClickMsg); isClick {
 			if m.Y == a.searchBarY() {
@@ -33,11 +30,10 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			}
 			return a.submitSearch()
 		}
-	}
+	}	
 
 	switch msg.(type) {
 	case tea.MouseWheelMsg:
-		// Scroll on tabs that use their own lists.
 		if a.activeTab == tabTransactions {
 			return a.onTransactionScroll(m.Button)
 		}
@@ -75,12 +71,10 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 		y := m.Y
 
-		// Click on tab bar (row 0) → switch tab
 		if y == 0 {
 			return a.onTabClick(m.X)
 		}
 
-		// Transactions/Repos/ErrorLog tabs: delegate to per-tab click handlers.
 		if a.activeTab == tabTransactions {
 			return a.onTransactionClick(m)
 		}
@@ -95,7 +89,6 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			return a.onSideBySideClick(m)
 		}
 
-		// Click on column header/separator area → toggle sort
 		if y >= packageListHeaderY && y < packageListStartY {
 			return a.onHeaderClick(m.X-1, a.width-2) // -1 for left panel border
 		}
@@ -114,7 +107,6 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
-		// If clicking the already-selected row, toggle its selection (check/uncheck)
 		if idx == a.selectedIdx {
 			if a.selected == nil {
 				a.selected = make(map[string]bool)
@@ -129,7 +121,6 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
-		// Move cursor to clicked row
 		a.selectedIdx = idx
 		a.adjustPackageScroll()
 		return a, a.updateSelectionCmd()

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -12,7 +12,7 @@ import (
 // Stacked layout: info panel (5 rows) sits above the list panel.
 // tabBar(1) + gap(1) + infoPanel(5) + gap(1) = 8, then border(1) + header(1) + sep(1).
 const (
-	packageListHeaderY = 8  
+	packageListHeaderY = 8
 	packageListStartY  = 10
 )
 
@@ -23,6 +23,17 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 	a.exportConfirm = false
 	m := msg.Mouse()
+
+	// If in search mode, clicking outside the search bar submits the search
+	// (like pressing Enter). Clicking on the search input row keeps search active.
+	if a.searching {
+		if _, isClick := msg.(tea.MouseClickMsg); isClick {
+			if m.Y == a.searchBarY() {
+				return a, nil
+			}
+			return a.submitSearch()
+		}
+	}
 
 	switch msg.(type) {
 	case tea.MouseWheelMsg:
@@ -86,7 +97,7 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 		// Click on column header/separator area → toggle sort
 		if y >= packageListHeaderY && y < packageListStartY {
-			return a.onHeaderClick(m.X - 1) // -1 for left panel border
+			return a.onHeaderClick(m.X-1, a.width-2) // -1 for left panel border
 		}
 
 		if y == a.searchBarY() && !a.searching {
@@ -146,9 +157,10 @@ func (a App) onTabClick(x int) (tea.Model, tea.Cmd) {
 }
 
 // onHeaderClick maps an X coordinate to a column and toggles sorting.
-func (a App) onHeaderClick(x int) (tea.Model, tea.Cmd) {
+// contentWidth is the inner width of the panel containing the header.
+func (a App) onHeaderClick(x int, contentWidth int) (tea.Model, tea.Cmd) {
 	prefixW := 11
-	available := a.width - prefixW - 4
+	available := contentWidth - prefixW - 4
 	if available < 40 {
 		available = 40
 	}
@@ -217,13 +229,13 @@ func (a App) onSideBySideClick(m tea.Mouse) (tea.Model, tea.Cmd) {
 	const sideListStartY = 10 // first package item row
 
 	// Click on search bar area → open search
-	if y == a.searchBarY() && !a.searching {
+	if a.inSearchBox(y) && !a.searching {
 		return a.openSearch()
 	}
 
 	// Column header click → sort toggle
 	if y >= sideListHeaderY && y < sideListStartY {
-		return a.onHeaderClick(m.X - 1) // -1 for left border
+		return a.onHeaderClick(m.X-1, a.sideListWidth()-2) // -1 for left border
 	}
 
 	row := y - sideListStartY


### PR DESCRIPTION
Fix #117.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `inSearchBox` helper to check if a Y coordinate falls within the full info panel (rows 2–6), then uses it to widen the click target for opening search in side-by-side mode. It also refactors `onHeaderClick` to accept an explicit `contentWidth` parameter, fixing column-boundary calculations when the panel is narrower than the full window.

- **`inSearchBox`** (helpers.go): new predicate covering the info panel including its borders; replaces the single-row `y == searchBarY()` test in `onSideBySideClick`.
- **`onHeaderClick` signature**: now takes `contentWidth` instead of implicitly using `a.width`, so sort-column hits are correct in both stacked and side-by-side layouts.
- **Searching guard** (keypress_mouse.go lines 26–33): early return that intercepts clicks while the search bar is active; missing a `m.Button != tea.MouseLeft` guard, which allows right-clicks and middle-clicks to accidentally submit the search.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the non-left-click search submission in the searching guard.

The new searching guard in `onMouseClick` fires on any `tea.MouseClickMsg` regardless of button — right-clicking anywhere outside the search-bar row while searching silently submits the query, bypassing the non-left-click filter that exists in the normal click path. All other changes (`inSearchBox`, the `contentWidth` parameter to `onHeaderClick`) look correct.

internal/app/keypress_mouse.go — the searching guard at lines 26–33.

<sub>Reviews (2): Last reviewed commit: ["Refactor onMouseClick to streamline sear..."](https://github.com/mexirica/aptui/commit/3bbba90d2fdd09b4b9f9ec3ef38d5d67588c9994) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31928453)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->