### PR TITLE
Feat: enhance package detail display with version

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -104,9 +104,9 @@ func searchPackagesCmd(query string) tea.Cmd {
 	}
 }
 
-func showPackageDetailCmd(name string) tea.Cmd {
+func showPackageDetailCmd(name string, version string) tea.Cmd {
 	return func() tea.Msg {
-		info, err := apt.ShowPackage(name)
+		info, err := apt.ShowPackage(name, version)
 		return detailLoadedMsg{name, info, err}
 	}
 }

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -403,7 +403,14 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 	if pkg.ManuallyInstalled {
 		manualLine = "Manual-Installed: yes"
 	}
-	return statusLine + "\n" + manualLine + "\n" + detailInfo
+	// Remove any raw Status line from apt-cache output to avoid overwriting enriched status.
+	var filtered []string
+	for _, line := range strings.Split(detailInfo, "\n") {
+		if !strings.HasPrefix(line, "Status:") {
+			filtered = append(filtered, line)
+		}
+	}
+	return statusLine + "\n" + manualLine + "\n" + strings.Join(filtered, "\n")
 }
 
 // adjustScroll clamps offset so that idx stays visible within height rows.

--- a/internal/app/keypress_actions.go
+++ b/internal/app/keypress_actions.go
@@ -74,14 +74,14 @@ func (a *App) updateSelectionCmd() tea.Cmd {
 	if len(a.filtered) == 0 || a.selectedIdx >= len(a.filtered) {
 		return nil
 	}
-	pkgName := a.filtered[a.selectedIdx].Name
-	cmds := []tea.Cmd{showPackageDetailCmd(pkgName)}
+	pkg := a.filtered[a.selectedIdx]
+	cmds := []tea.Cmd{showPackageDetailCmd(pkg.Name, pkg.Version)}
 	if a.fileListActive {
-		a.fileListPkg = pkgName
+		a.fileListPkg = pkg.Name
 		a.fileListItems = nil
 		a.fileListIdx = 0
 		a.fileListOffset = 0
-		cmds = append(cmds, loadFileListCmd(pkgName))
+		cmds = append(cmds, loadFileListCmd(pkg.Name))
 	}
 	return tea.Batch(cmds...)
 }

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -188,10 +188,10 @@ func SearchPackages(query string) ([]model.Package, error) {
 	return parseSearchOutput(out.String()), nil
 }
 
-func ShowPackage(name string, version ...string) (string, error) {
+func ShowPackage(name string, version string) (string, error) {
 	pkgArg := name
-	if len(version) > 0 && version[0] != "" {
-		pkgArg = name + "=" + version[0]
+	if version != "" {
+		pkgArg = name + "=" + version
 	}
 	cmd := exec.Command("apt-cache", "show", pkgArg)
 	var out bytes.Buffer

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -188,8 +188,12 @@ func SearchPackages(query string) ([]model.Package, error) {
 	return parseSearchOutput(out.String()), nil
 }
 
-func ShowPackage(name string) (string, error) {
-	cmd := exec.Command("apt-cache", "show", name)
+func ShowPackage(name string, version ...string) (string, error) {
+	pkgArg := name
+	if len(version) > 0 && version[0] != "" {
+		pkgArg = name + "=" + version[0]
+	}
+	cmd := exec.Command("apt-cache", "show", pkgArg)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/internal/ui/components/packagelist.go
+++ b/internal/ui/components/packagelist.go
@@ -160,7 +160,7 @@ func RenderPackageList(packages []model.Package, selected int, offset int, maxVi
 		name += pinnedSuffix + essentialSuffix + manualSuffix
 
 		version := pkg.Version
-		if pkg.NewVersion != "" {
+		if version == "" && pkg.NewVersion != "" {
 			version = pkg.NewVersion
 		}
 		if version == "" {


### PR DESCRIPTION
Fix #119.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR passes the selected package's installed version to `apt-cache show` so the detail pane displays the correct version-specific information, and removes duplicate raw `Status:` lines from that output in favour of the enriched status already prepended by `enrichedDetailInfo`.

- `client.go` / `commands.go` / `keypress_actions.go`: `ShowPackage` now accepts an explicit version string and constructs the `name=version` argument for `apt-cache show`, ensuring the detail view matches the installed (selected) version.
- `helpers.go`: Filters out any `Status:` lines returned by `apt-cache show` to prevent them from overwriting the richer status built by the application.
- `packagelist.go`: The version column now prefers the installed `pkg.Version` and only falls back to `pkg.NewVersion` when the former is empty, instead of always overriding with `NewVersion`.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped and safe to merge — they pass the installed version through to `apt-cache show` and clean up duplicate status output.

All changed code paths are straightforward: the version string is passed as a single argument to `exec.Command` (no shell involved, so no injection risk), the `Status:` line filter in `helpers.go` is correct, and the `packagelist.go` fallback logic is intentional. No incorrect data handling or broken contracts were found.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["Feat: update ShowPackage function to acc..."](https://github.com/mexirica/aptui/commit/45282a87b2e8177bdb657054ab5a237b284b61ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31931959)</sub>

<!-- /greptile_comment -->