### PR TITLE
Feat: improve markers visibility

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2165,6 +2165,30 @@ func TestOnPackageDetailLoaded_Error(t *testing.T) {
 	}
 }
 
+func TestOnPackageDetailLoaded_EssentialPropagated(t *testing.T) {
+	a := newTestApp()
+	a.infoCache = map[string]apt.PackageInfo{}
+	a.essentialSet = map[string]bool{}
+	a.filtered = []model.Package{{Name: "base-files", Installed: true}}
+	a.allPackages = []model.Package{{Name: "base-files", Installed: true}}
+	a.rebuildIndex()
+
+	info := "Package: base-files\nVersion: 12\nInstalled-Size: 340\nEssential: yes\nSection: admin\nArchitecture: amd64\nDescription: Debian base system miscellaneous files"
+	msg := detailLoadedMsg{name: "base-files", info: info}
+	m, _ := a.onPackageDetailLoaded(msg)
+	app := m.(App)
+
+	if !app.essentialSet["base-files"] {
+		t.Error("essentialSet should contain base-files after detail load")
+	}
+	if !app.filtered[0].Essential {
+		t.Error("filtered entry should have Essential=true after detail load")
+	}
+	if idx, ok := app.pkgIndex["base-files"]; !ok || !app.allPackages[idx].Essential {
+		t.Error("allPackages entry should have Essential=true after detail load")
+	}
+}
+
 func TestOnDepsLoaded(t *testing.T) {
 	a := newTestApp()
 	a.transactionIdx = 2

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -409,10 +409,10 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 	if pkg.Essential {
 		essentialLine = "Essential: yes"
 	}
-	// Remove any raw Status line from apt-cache output to avoid overwriting enriched status.
+	// Remove raw Status/Essential lines from apt-cache output to avoid overwriting enriched values.
 	var filtered []string
 	for _, line := range strings.Split(detailInfo, "\n") {
-		if !strings.HasPrefix(line, "Status:") {
+		if !strings.HasPrefix(line, "Status:") && !strings.HasPrefix(line, "Essential:") {
 			filtered = append(filtered, line)
 		}
 	}

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -405,6 +405,10 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 	if pkg.ManuallyInstalled {
 		manualLine = "Manual-Installed: yes"
 	}
+	essentialLine := "Essential: no"
+	if pkg.Essential {
+		essentialLine = "Essential: yes"
+	}
 	// Remove any raw Status line from apt-cache output to avoid overwriting enriched status.
 	var filtered []string
 	for _, line := range strings.Split(detailInfo, "\n") {
@@ -412,7 +416,7 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 			filtered = append(filtered, line)
 		}
 	}
-	extra := statusLine + "\n" + manualLine
+	extra := statusLine + "\n" + manualLine + "\n" + essentialLine
 	if pkg.Origin != "" {
 		extra += "\nOrigins: " + pkg.Origin
 	}

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -405,11 +405,21 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 	if pkg.ManuallyInstalled {
 		manualLine = "Manual-Installed: yes"
 	}
+	// Derive essential state: model field takes priority; fall back to raw
+	// apt-cache show output in case pkg.Essential was not populated.
+	isEssential := pkg.Essential
+	if !isEssential {
+		for _, line := range strings.Split(detailInfo, "\n") {
+			if strings.HasPrefix(line, "Essential: yes") {
+				isEssential = true
+				break
+			}
+		}
+	}
 	essentialLine := "Essential: no"
-	if pkg.Essential {
+	if isEssential {
 		essentialLine = "Essential: yes"
 	}
-	// Remove raw Status/Essential lines from apt-cache output to avoid overwriting enriched values.
 	var filtered []string
 	for _, line := range strings.Split(detailInfo, "\n") {
 		if !strings.HasPrefix(line, "Status:") && !strings.HasPrefix(line, "Essential:") {

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -30,7 +30,7 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			}
 			return a.submitSearch()
 		}
-	}	
+	}
 
 	switch msg.(type) {
 	case tea.MouseWheelMsg:

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -343,6 +343,7 @@ func (a App) onSearchResultLoaded(msg searchResultMsg) (tea.Model, tea.Cmd) {
 			msg.pkgs[i].Architecture = inst.Architecture
 			msg.pkgs[i].Origin = inst.Origin
 			msg.pkgs[i].ManuallyInstalled = inst.ManuallyInstalled
+			msg.pkgs[i].Essential = a.essentialSet[msg.pkgs[i].Name]
 			if msg.pkgs[i].Description == "" {
 				msg.pkgs[i].Description = inst.Description
 			}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -342,6 +342,7 @@ func (a App) onSearchResultLoaded(msg searchResultMsg) (tea.Model, tea.Cmd) {
 			msg.pkgs[i].Section = inst.Section
 			msg.pkgs[i].Architecture = inst.Architecture
 			msg.pkgs[i].Origin = inst.Origin
+			msg.pkgs[i].ManuallyInstalled = inst.ManuallyInstalled
 			if msg.pkgs[i].Description == "" {
 				msg.pkgs[i].Description = inst.Description
 			}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -409,6 +409,9 @@ func (a App) onPackageDetailLoaded(msg detailLoadedMsg) (tea.Model, tea.Cmd) {
 				pi.Origins = existing.Origins
 			}
 			a.infoCache[msg.name] = pi
+			if pi.Essential {
+				a.essentialSet[msg.name] = true
+			}
 			for i := range a.filtered {
 				if a.filtered[i].Name == msg.name {
 					if a.filtered[i].Version == "" && a.filtered[i].NewVersion == "" {
@@ -425,6 +428,9 @@ func (a App) onPackageDetailLoaded(msg detailLoadedMsg) (tea.Model, tea.Cmd) {
 					}
 					if a.filtered[i].Description == "" {
 						a.filtered[i].Description = pi.Description
+					}
+					if pi.Essential {
+						a.filtered[i].Essential = true
 					}
 					break
 				}
@@ -444,6 +450,9 @@ func (a App) onPackageDetailLoaded(msg detailLoadedMsg) (tea.Model, tea.Cmd) {
 				}
 				if a.allPackages[idx].Description == "" {
 					a.allPackages[idx].Description = pi.Description
+				}
+				if pi.Essential {
+					a.allPackages[idx].Essential = true
 				}
 			}
 		}

--- a/internal/ui/components/components_test.go
+++ b/internal/ui/components/components_test.go
@@ -269,18 +269,6 @@ func TestRenderPackageListHeldBadge(t *testing.T) {
 	}
 }
 
-func TestRenderPackageListEssentialBadge(t *testing.T) {
-	pkgs := []model.Package{
-		{Name: "base-files", Version: "12", Installed: true, Essential: true},
-		{Name: "vim", Version: "8.2", Installed: true},
-	}
-
-	result := RenderPackageList(pkgs, 0, 0, 10, 120, nil)
-	if !strings.Contains(result, "◈") {
-		t.Error("essential package should show shield badge")
-	}
-}
-
 func TestWrapText(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/ui/components/packagedetail.go
+++ b/internal/ui/components/packagedetail.go
@@ -31,6 +31,7 @@ var displayFields = []string{
 	"Breaks",
 	"Replaces",
 	"Manual-Installed",
+	"Essential",
 	"Description",
 	"Homepage",
 }

--- a/internal/ui/components/packagelist.go
+++ b/internal/ui/components/packagelist.go
@@ -24,7 +24,7 @@ func RenderPackageList(packages []model.Package, selected int, offset int, maxVi
 	selCheckStyle := lipgloss.NewStyle().Foreground(ui.ColorAccent).Bold(true)
 	selUncheckStyle := lipgloss.NewStyle().Foreground(ui.ColorUncheck)
 
-	// prefix takes: cursor(3) + space(1) + selMarker(3) + space(1) + badge(26) + space(1) = ~11
+	// prefix takes: cursor(3) + space(1) + selMarker(3) + space(1) + badge(2) + space(1) = 11
 	prefixW := 11
 	available := width - prefixW - 4 // 4 for column gaps (2 between each)
 	if available < 40 {
@@ -138,26 +138,16 @@ func RenderPackageList(packages []model.Package, selected int, offset int, maxVi
 
 		name := pkg.Name
 		isPinned := pkg.Pinned
-		pinnedSuffix := ""
-		essentialSuffix := ""
-		manualSuffix := ""
 		maxLen := colName
 		if isPinned {
-			pinnedSuffix = " ★"
 			maxLen -= 2 // reserve space for " ★"
-		}
-		if pkg.Essential {
-			essentialSuffix = " ◈"
-			maxLen -= 2 // reserve space for " ◈"
-		}
-		if pkg.ManuallyInstalled {
-			manualSuffix = " ᴹ"
-			maxLen -= 2 // reserve space for " ᴹ"
 		}
 		if len(name) > maxLen && maxLen > 0 {
 			name = name[:maxLen-1] + "…"
 		}
-		name += pinnedSuffix + essentialSuffix + manualSuffix
+		if isPinned {
+			name += " ★"
+		}
 
 		version := pkg.Version
 		if version == "" && pkg.NewVersion != "" {


### PR DESCRIPTION
Fix #123.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves package visibility markers into the detail panel and propagates essential package state more consistently. It changes:

- Adds `Essential` to the package detail display.
- Enriches detail text with normalized status, manual install, and essential fields.
- Removes manual and essential suffix markers from the package list rows.
- Propagates parsed essential state into cached package data and visible package entries.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The latest detail-load changes keep essential state aligned across the cache, filtered list, and all packages.

<sub>Reviews (7): Last reviewed commit: ["Feat: propagate essential status in onPa..."](https://github.com/mexirica/aptui/commit/feb1eb5c68a63f98266e85092b8d3bca4a10aac0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32496130)</sub>

<!-- /greptile_comment -->