### PR TITLE
0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Built with [Bubble Tea](https://github.com/charmbracelet/bubbletea), [Lip Gloss]
 ## Features
 
 - **Browse all packages** — lists every available APT package with version and size info loaded lazily
-- **Search & filter** — single bar for fuzzy search and structured filters (section, architecture, size, status and more) ([docs](docs/filter.md))
+- **Search & filter** — single bar for fuzzy search and structured filters (section, architecture, size, status, repository origin and more) ([docs](docs/filter.md))
+- **Repository origin filter** — press `o` to open a dropdown listing all package origins; selecting one injects a `repo:` token into the filter bar, which you can further combine with text search
 - **Column sorting** — sort packages by name, version, size, section or architecture; click headers to cycle ascending → descending → clear
 - **Tabs** — switch between *All*, *Installed*, *Upgradable*, *Cleanup*, *Errors*, *Transactions* and *Repos* views; tabs with pending items highlight in yellow
 - **Multi-select** — mark multiple packages with `space`, then bulk install/remove/upgrade
@@ -142,17 +143,20 @@ Navigate tabs with `tab` / `shift+tab`, or click on them.
 | Key | Action |
 |---|---|
 | `/` | Open [search/filter](docs/filter.md) bar |
+| `o` | Open repository origin filter dropdown |
 | `enter` | Confirm search / apply filter |
 | `esc` | Clear search / filter / go back |
 
 #### Examples
 
 ```
-vim                          # fuzzy search for "vim"
-section:editors vim          # filter by section + fuzzy search combined
-installed size>10MB          # installed packages larger than 10 MB
-section:utils order:name     # packages in "utils" section, sorted A→Z
-order:size:desc              # all packages sorted by size, largest first
+vim                                    # fuzzy search for "vim"
+section:editors vim                    # filter by section + fuzzy search combined
+installed size>10MB                    # installed packages larger than 10 MB
+section:utils order:name               # packages in "utils" section, sorted A→Z
+order:size:desc                        # all packages sorted by size, largest first
+repo:ubuntu noble/main                 # packages from a specific repository origin
+"repo:apt.pop-os.org/ubuntu noble/main" installed  # combine repo filter with other tokens
 ```
 
 See the full [search & filter documentation](docs/filter.md) for all available options.
@@ -189,6 +193,7 @@ See the full [search & filter documentation](docs/filter.md) for all available o
 | `M` | Export only manually installed packages to JSON file |
 | `I` | Import packages from JSON file |
 | `v` | Open version selector for current package ([docs](docs/version.md)) |
+| `o` | Open repository origin filter dropdown |
 | `U` | Run `apt-get update` |
 | `ctrl+r` | Refresh package list |
 

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -11,6 +11,7 @@ Press **`/`** on the main package screen. A unified input bar will appear at the
 | Key       | Action                                        |
 |-----------|-----------------------------------------------|
 | `/`       | Open the search/filter bar                    |
+| `o`       | Open the repository origin filter dropdown    |
 | `Enter`   | Apply the query                               |
 | `Esc`     | Cancel input / clear the active query         |
 
@@ -36,13 +37,14 @@ A query is composed of **tokens** separated by spaces. Filter tokens are combine
 
 These filters check whether the field value **contains** the given text (case-insensitive):
 
-| Filter                     | Shorthand  | Description                          |
-|----------------------------|------------|--------------------------------------|
-| `section:<text>`           | `sec:`     | Package section contains `<text>`    |
-| `name:<text>`              | —          | Package name contains `<text>`       |
-| `version:<text>`           | `ver:`     | Package version contains `<text>`    |
-| `description:<text>`       | `desc:`    | Package description contains `<text>`|
-| `arch:<text>`              | `architecture:` | Package architecture equals `<text>` exactly |
+| Filter                     | Shorthand       | Description                                   |
+|----------------------------|-----------------|-----------------------------------------------|
+| `section:<text>`           | `sec:`          | Package section contains `<text>`             |
+| `name:<text>`              | —               | Package name contains `<text>`                |
+| `version:<text>`           | `ver:`          | Package version contains `<text>`             |
+| `description:<text>`       | `desc:`         | Package description contains `<text>`         |
+| `arch:<text>`              | `architecture:` | Package architecture equals `<text>` exactly  |
+| `repo:<text>`              | `origin:`       | Package repository origin contains `<text>`   |
 
 **Examples:**
 
@@ -55,7 +57,19 @@ desc:text editor    → packages whose description contains "text" ("editor" bec
 arch:amd64          → packages with architecture exactly "amd64"
 arch:arm64          → packages with architecture exactly "arm64"
 arch:all            → architecture-independent packages
+repo:ubuntu         → packages from any origin containing "ubuntu"
+repo:noble/main     → packages from the "noble/main" component of any mirror
+origin:pop-os       → packages from Pop!_OS repositories
 ```
+
+> **Tip — origins with spaces:** Repository origin strings often contain spaces (e.g. `archive.ubuntu.com/ubuntu noble/main`). Wrap the value in double quotes to treat it as a single token:
+>
+> ```
+> repo:"archive.ubuntu.com/ubuntu noble/main"
+> repo:"apt.pop-os.org/ubuntu noble/main" installed
+> ```
+>
+> The easiest way to apply an origin filter is to press **`o`** from the package list, which opens a dropdown of all detected origins and automatically injects the correctly-quoted `repo:` token into the filter bar.
 
 ### Boolean filters
 
@@ -245,6 +259,53 @@ Tabs (All / Installed / Upgradable, toggled with `Tab`) are applied **before** t
 ## Fallback to APT cache
 
 If a fuzzy search returns **0 results** from the loaded package list, APTUI automatically falls back to `apt-cache search <query>` to search the full APT cache. This ensures you can still find packages that may not have been loaded yet.
+
+---
+
+## Repository origin filter
+
+Press **`o`** from the package list to open a dropdown listing all repository origins detected from the locally cached APT metadata.
+
+### How it works
+
+1. APTUI scans all loaded packages and collects their unique repository origin strings (e.g. `archive.ubuntu.com/ubuntu noble/main`, `apt.pop-os.org/ubuntu noble/main`).
+2. An overlay appears. Navigate with `↑` / `↓` and press `Enter` to select.
+3. Selecting an origin automatically writes a `repo:"..."` token into the filter bar (with quotes when the origin contains spaces) and closes the dropdown.
+4. Press **`/`** at any time to open the filter bar — it will already contain the injected `repo:` token. You can add more tokens or free text alongside it.
+5. Selecting the `[Clear repo filter]` entry at the top removes the `repo:` token.
+6. Pressing `Esc` from the dropdown discards any selection and returns to the package list.
+
+### Controls
+
+| Key              | Action                                   |
+|------------------|------------------------------------------|
+| `o`              | Open the repository origin dropdown      |
+| `↑` / `k`        | Move selection up                        |
+| `↓` / `j`        | Move selection down                      |
+| `pgup` / `ctrl+u`| Page up                                  |
+| `pgdn` / `ctrl+d`| Page down                                |
+| `enter`          | Apply selected origin as `repo:` filter  |
+| `esc`            | Cancel and return to package list        |
+
+### Example workflow
+
+1. Press `o` — dropdown appears showing origins such as:
+   ```
+   [Clear repo filter]
+   apt.pop-os.org/ubuntu noble/main
+   archive.ubuntu.com/ubuntu noble/main
+   archive.ubuntu.com/ubuntu noble/universe
+   security.ubuntu.com/ubuntu noble-security/main
+   ```
+2. Select `archive.ubuntu.com/ubuntu noble/main` → the filter bar now shows:
+   ```
+   repo:"archive.ubuntu.com/ubuntu noble/main"
+   ```
+3. Press `/` to open the bar and add a text search:
+   ```
+   repo:"archive.ubuntu.com/ubuntu noble/main" python
+   ```
+   This shows only packages from that repo whose name/description fuzzy-matches "python".
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	charm.land/bubbles/v2 v2.1.0
-	charm.land/bubbletea/v2 v2.0.6
+	charm.land/bubbletea/v2 v2.0.7
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/charmbracelet/x/ansi v0.11.7
 )
@@ -12,7 +12,7 @@ require (
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
@@ -24,5 +24,5 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
 charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
-charm.land/bubbletea/v2 v2.0.6 h1:UHN/91OyuhaOFGSrBXQ/hMZD8IO1Uc4BvHlgHXL2WJo=
-charm.land/bubbletea/v2 v2.0.6/go.mod h1:MH/D8ZLlN3op37vQvijKuU29g3rqTp+aQapURFonF9g=
+charm.land/bubbletea/v2 v2.0.7 h1:7qw2tTAVar7m7klOPBYfTB0mniv/RuexsYwMRNxSeL0=
+charm.land/bubbletea/v2 v2.0.7/go.mod h1:DGW2q8gvzHnOpMpZTORs0aySVHCox5C+2Svk0fci1qs=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
@@ -10,8 +10,8 @@ github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 h1:Q9fO0y1Zo5KB/5Vu8JZoLGm1N3RzF9bNj3Ao3xoR+Ac=
-github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468/go.mod h1:bAAz7dh/FTYfC+oiHavL4mX1tOIBZ0ZwYjSi3qE6ivM=
+github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 h1:FpSYhY28ucg9ZRr+2wj67FAQ0Ey5yiK0072PmRDJNek=
+github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654/go.mod h1:hFpumms29Smx3LStRfku8vcCTBe1Kq8aCXtHUJa3mjY=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
@@ -40,5 +40,5 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -49,8 +49,6 @@ var tabDefs = []tabDef{
 	{" ◆ Repos ", tabRepos, "Repos"},
 }
 
-// App is the main Bubbletea model. It manages three views:
-// the package list (default), the transaction history, and the mirror selector.
 type App struct {
 	allPackages   []model.Package
 	filtered      []model.Package
@@ -65,7 +63,6 @@ type App struct {
 	detailName         string
 	detailScrollOffset int
 
-	// Search state
 	searchInput           textinput.Model
 	searching             bool
 	filterQuery           string

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -163,6 +163,11 @@ type App struct {
 	versionPrevVer     string // version installed before version change
 	versionIsDowngrade bool
 
+	repoFilterView   bool
+	repoFilterItems  []string // unique repo origins
+	repoFilterIdx    int
+	repoFilterOffset int
+
 	installRecommends bool
 	installSuggests   bool
 	autoUpdate        bool
@@ -197,7 +202,7 @@ func New() App {
 	}
 
 	ti := textinput.New()
-	ti.Placeholder = "Search or filter: section: arch: size> installed ..."
+	ti.Placeholder = "Search or filter: section: arch: size> repo: installed ..."
 	ti.CharLimit = 200
 	ti.SetWidth(80)
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2165,6 +2165,30 @@ func TestOnPackageDetailLoaded_Error(t *testing.T) {
 	}
 }
 
+func TestOnPackageDetailLoaded_EssentialPropagated(t *testing.T) {
+	a := newTestApp()
+	a.infoCache = map[string]apt.PackageInfo{}
+	a.essentialSet = map[string]bool{}
+	a.filtered = []model.Package{{Name: "base-files", Installed: true}}
+	a.allPackages = []model.Package{{Name: "base-files", Installed: true}}
+	a.rebuildIndex()
+
+	info := "Package: base-files\nVersion: 12\nInstalled-Size: 340\nEssential: yes\nSection: admin\nArchitecture: amd64\nDescription: Debian base system miscellaneous files"
+	msg := detailLoadedMsg{name: "base-files", info: info}
+	m, _ := a.onPackageDetailLoaded(msg)
+	app := m.(App)
+
+	if !app.essentialSet["base-files"] {
+		t.Error("essentialSet should contain base-files after detail load")
+	}
+	if !app.filtered[0].Essential {
+		t.Error("filtered entry should have Essential=true after detail load")
+	}
+	if idx, ok := app.pkgIndex["base-files"]; !ok || !app.allPackages[idx].Essential {
+		t.Error("allPackages entry should have Essential=true after detail load")
+	}
+}
+
 func TestOnDepsLoaded(t *testing.T) {
 	a := newTestApp()
 	a.transactionIdx = 2

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -104,9 +104,9 @@ func searchPackagesCmd(query string) tea.Cmd {
 	}
 }
 
-func showPackageDetailCmd(name string) tea.Cmd {
+func showPackageDetailCmd(name string, version string) tea.Cmd {
 	return func() tea.Msg {
-		info, err := apt.ShowPackage(name)
+		info, err := apt.ShowPackage(name, version)
 		return detailLoadedMsg{name, info, err}
 	}
 }

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -171,10 +171,11 @@ func (a *App) applyFilter(preserveSelection bool) {
 
 	af := filter.Parse(a.filterQuery)
 
-	// Apply structured filter criteria (section:, arch:, size>, etc.)
+	// Apply structured filter criteria (section:, arch:, size>, repo:, etc.)
 	if af.Section != "" || af.Architecture != "" || af.Size != nil ||
 		af.Installed != nil || af.Upgradable != nil ||
-		af.Name != "" || af.Version != "" || af.Description != "" {
+		af.Name != "" || af.Version != "" || af.Description != "" ||
+		af.Origin != "" {
 		var filtered []model.Package
 		for _, p := range source {
 			pd := filter.PackageData{
@@ -187,6 +188,7 @@ func (a *App) applyFilter(preserveSelection bool) {
 				Upgradable:   p.Upgradable,
 				Section:      p.Section,
 				Architecture: p.Architecture,
+				Origin:       p.Origin,
 			}
 			if af.Match(pd) {
 				filtered = append(filtered, p)
@@ -410,7 +412,11 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 			filtered = append(filtered, line)
 		}
 	}
-	return statusLine + "\n" + manualLine + "\n" + strings.Join(filtered, "\n")
+	extra := statusLine + "\n" + manualLine
+	if pkg.Origin != "" {
+		extra += "\nOrigins: " + pkg.Origin
+	}
+	return extra + "\n" + strings.Join(filtered, "\n")
 }
 
 // adjustScroll clamps offset so that idx stays visible within height rows.

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -498,6 +498,13 @@ func (a App) searchBarY() int {
 	return 3
 }
 
+// inSearchBox reports whether the given Y coordinate falls within the
+// search/status info panel (border included).
+func (a App) inSearchBox(y int) bool {
+	top := a.searchBarY() - 1 // top border row
+	return y >= top && y < top+infoRowH
+}
+
 // Layout constants and helpers.
 const (
 	infoRowH     = 5  // 3 inner lines + 2 border lines

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -403,7 +403,14 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 	if pkg.ManuallyInstalled {
 		manualLine = "Manual-Installed: yes"
 	}
-	return statusLine + "\n" + manualLine + "\n" + detailInfo
+	// Remove any raw Status line from apt-cache output to avoid overwriting enriched status.
+	var filtered []string
+	for _, line := range strings.Split(detailInfo, "\n") {
+		if !strings.HasPrefix(line, "Status:") {
+			filtered = append(filtered, line)
+		}
+	}
+	return statusLine + "\n" + manualLine + "\n" + strings.Join(filtered, "\n")
 }
 
 // adjustScroll clamps offset so that idx stays visible within height rows.

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -405,14 +405,28 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 	if pkg.ManuallyInstalled {
 		manualLine = "Manual-Installed: yes"
 	}
-	// Remove any raw Status line from apt-cache output to avoid overwriting enriched status.
+	// Derive essential state: model field takes priority; fall back to raw
+	// apt-cache show output in case pkg.Essential was not populated.
+	isEssential := pkg.Essential
+	if !isEssential {
+		for _, line := range strings.Split(detailInfo, "\n") {
+			if strings.HasPrefix(line, "Essential: yes") {
+				isEssential = true
+				break
+			}
+		}
+	}
+	essentialLine := "Essential: no"
+	if isEssential {
+		essentialLine = "Essential: yes"
+	}
 	var filtered []string
 	for _, line := range strings.Split(detailInfo, "\n") {
-		if !strings.HasPrefix(line, "Status:") {
+		if !strings.HasPrefix(line, "Status:") && !strings.HasPrefix(line, "Essential:") {
 			filtered = append(filtered, line)
 		}
 	}
-	extra := statusLine + "\n" + manualLine
+	extra := statusLine + "\n" + manualLine + "\n" + essentialLine
 	if pkg.Origin != "" {
 		extra += "\nOrigins: " + pkg.Origin
 	}

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -22,7 +22,6 @@ type scoredPackage struct {
 	score int
 }
 
-// applyComponentStyles refreshes help and spinner styles after a theme change.
 func (a *App) applyComponentStyles() {
 	a.help.Styles.ShortKey = lipgloss.NewStyle().Foreground(ui.ColorPrimary).Bold(true)
 	a.help.Styles.FullKey = lipgloss.NewStyle().Foreground(ui.ColorPrimary).Bold(true)
@@ -33,7 +32,6 @@ func (a *App) applyComponentStyles() {
 	a.spinner.Style = lipgloss.NewStyle().Foreground(ui.ColorPrimary)
 }
 
-// tabStyle returns the appropriate style for a tab given the current state.
 func (a App) tabStyle(t tabDef) lipgloss.Style {
 	if t.kind == a.activeTab {
 		return ui.TabActiveStyle
@@ -50,15 +48,12 @@ func (a App) tabStyle(t tabDef) lipgloss.Style {
 	return ui.TabInactiveStyle
 }
 
-// tabLabels returns the actual labels displayed on the tab bar,
-// accounting for progressive truncation when the terminal is narrow.
 func (a App) tabLabels() []string {
 	labels := make([]string, len(tabDefs))
 	for i, t := range tabDefs {
 		labels[i] = t.label
 	}
 
-	// Check if full labels fit.
 	var total int
 	for i, t := range tabDefs {
 		total += lipgloss.Width(a.tabStyle(t).Render(labels[i]))
@@ -67,7 +62,6 @@ func (a App) tabLabels() []string {
 		return labels
 	}
 
-	// Use short names and progressively truncate until they fit.
 	names := make([]string, len(tabDefs))
 	for i, t := range tabDefs {
 		names[i] = t.name
@@ -97,7 +91,6 @@ func (a App) tabLabels() []string {
 	}
 }
 
-// activateTab switches to the given tab and returns the commands to refresh the view.
 func (a *App) activateTab() tea.Cmd {
 	if a.activeTab == tabErrorLog {
 		a.errlogItems = a.errlogStore.All()
@@ -133,11 +126,6 @@ func (a *App) activateTab() tea.Cmd {
 	return cmd
 }
 
-// applyFilter rebuilds the filtered list from allPackages based on active tab,
-// advanced filter, and search query. Uses fuzzy scoring when a search query is active.
-// When preserveSelection is true the cursor is kept on the same package after the
-// rebuild (used when the query itself did not change, e.g. the user clicked a row
-// while the search input was active). Pass false to reset the cursor to the top.
 func (a *App) applyFilter(preserveSelection bool) {
 	var selectedName string
 	if preserveSelection && a.selectedIdx >= 0 && a.selectedIdx < len(a.filtered) {
@@ -171,7 +159,6 @@ func (a *App) applyFilter(preserveSelection bool) {
 
 	af := filter.Parse(a.filterQuery)
 
-	// Apply structured filter criteria (section:, arch:, size>, repo:, etc.)
 	if af.Section != "" || af.Architecture != "" || af.Size != nil ||
 		af.Installed != nil || af.Upgradable != nil ||
 		af.Name != "" || af.Version != "" || af.Description != "" ||
@@ -197,7 +184,6 @@ func (a *App) applyFilter(preserveSelection bool) {
 		source = filtered
 	}
 
-	// Apply fuzzy search on free text (unrecognized tokens)
 	freeText := af.FreeText
 	if freeText == "" {
 		a.filtered = source
@@ -233,7 +219,6 @@ func (a *App) applyFilter(preserveSelection bool) {
 		}
 	}
 
-	// Apply sorting: click-based sort takes priority over filter-based sort
 	sortCol := af.OrderBy
 	sortDesc := af.OrderDesc
 	if a.sortColumn != filter.SortNone {
@@ -244,7 +229,6 @@ func (a *App) applyFilter(preserveSelection bool) {
 		sort.SliceStable(a.filtered, func(i, j int) bool {
 			pi, pj := a.filtered[i], a.filtered[j]
 
-			// Push packages with unknown data to the end
 			iEmpty, jEmpty := sortFieldEmpty(pi, sortCol), sortFieldEmpty(pj, sortCol)
 			if iEmpty != jEmpty {
 				return !iEmpty // non-empty comes first
@@ -283,8 +267,6 @@ func (a *App) applyFilter(preserveSelection bool) {
 		})
 	}
 
-	// Restore cursor to the previously selected package, or reset to 0 if it
-	// is no longer in the filtered list.
 	a.selectedIdx = 0
 	a.scrollOffset = 0
 	if selectedName != "" {
@@ -298,8 +280,6 @@ func (a *App) applyFilter(preserveSelection bool) {
 	}
 }
 
-// effectiveSortInfo returns the active sort state, preferring click-based sort
-// over filter-based sort.
 func (a App) effectiveSortInfo() filter.SortInfo {
 	if a.sortColumn != filter.SortNone {
 		return filter.SortInfo{Column: a.sortColumn, Desc: a.sortDesc}
@@ -325,7 +305,6 @@ func sortFieldEmpty(p model.Package, col filter.SortColumn) bool {
 	}
 }
 
-// rebuildIndex rebuilds the package name to index mapping for O(1) lookups.
 func (a *App) rebuildIndex() {
 	a.pkgIndex = make(map[string]int, len(a.allPackages))
 	for i, p := range a.allPackages {
@@ -333,8 +312,6 @@ func (a *App) rebuildIndex() {
 	}
 }
 
-// applyOptimisticUpdate updates in-memory package state immediately after
-// a successful operation, avoiding the need to wait for a full reload.
 func (a *App) applyOptimisticUpdate(op string, pkgs []string) {
 	switch op {
 	case "install":
@@ -390,8 +367,6 @@ func (a *App) applyOptimisticUpdate(op string, pkgs []string) {
 	a.applyFilter(true)
 }
 
-// enrichedDetailInfo prepends status and manual-install lines to raw
-// detail info for display in the detail panel.
 func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 	statusLine := "Status: Not installed"
 	if pkg.Held {
@@ -433,7 +408,6 @@ func enrichedDetailInfo(pkg model.Package, detailInfo string) string {
 	return extra + "\n" + strings.Join(filtered, "\n")
 }
 
-// adjustScroll clamps offset so that idx stays visible within height rows.
 func adjustScroll(idx int, offset *int, height int) {
 	if idx < *offset {
 		*offset = idx
@@ -455,8 +429,6 @@ func (a *App) adjustTransactionScroll() {
 	adjustScroll(a.transactionIdx, &a.transactionOffset, a.transactionListHeight())
 }
 
-// detailContentMaxScroll returns the maximum scroll offset for the detail
-// panel based on the rendered content and visible area.
 func (a App) detailContentMaxScroll() int {
 	if len(a.filtered) == 0 || a.selectedIdx >= len(a.filtered) {
 		return 0
@@ -469,7 +441,6 @@ func (a App) detailContentMaxScroll() int {
 		visibleH = a.stackedDetailPanelHeight() - 2
 		width = a.width - 2
 	}
-	// Render to get the actual formatted content with word-wrap.
 	var content string
 	if a.detailInfo != "" {
 		content = components.RenderPackageDetail(enrichedDetailInfo(a.filtered[a.selectedIdx], a.detailInfo), width, 0, 1)
@@ -484,15 +455,11 @@ func (a App) detailContentMaxScroll() int {
 	return maxOffset
 }
 
-// scrollDetailView is a convenience wrapper around scrollDetailContent that
-// returns only the visible text, discarding offset metadata.
 func scrollDetailView(content string, maxLines int, offset int) string {
 	s, _, _ := scrollDetailContent(content, maxLines, offset)
 	return s
 }
 
-// scrollDetailContent applies the detail scroll offset to rendered content,
-// returning at most maxLines visible lines and the clamped offset/maxScroll.
 func scrollDetailContent(content string, maxLines int, offset int) (string, int, int) {
 	lines := strings.Split(content, "\n")
 	// Remove trailing empty line from final \n
@@ -518,21 +485,17 @@ func scrollDetailContent(content string, maxLines int, offset int) (string, int,
 	return strings.Join(lines[start:end], "\n") + "\n", offset, maxOffset
 }
 
-// searchBarY returns the Y coordinate of the search bar row.
 func (a App) searchBarY() int {
 	// Info panel is now directly below the tab bar (+ gap line).
 	// Tab(1) + gap(1) + top border of info panel(1) = 3
 	return 3
 }
 
-// inSearchBox reports whether the given Y coordinate falls within the
-// search/status info panel (border included).
 func (a App) inSearchBox(y int) bool {
 	top := a.searchBarY() - 1 // top border row
 	return y >= top && y < top+infoRowH
 }
 
-// Layout constants and helpers.
 const (
 	infoRowH     = 5  // 3 inner lines + 2 border lines
 	sideSplitPct = 60 // left panel percentage

--- a/internal/app/keypress.go
+++ b/internal/app/keypress.go
@@ -92,6 +92,8 @@ func (a App) onKeypress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return a.reloadPackages()
 	case "f":
 		return a.openFetchMirrors()
+	case "o":
+		return a.openRepoFilter()
 	case "D":
 		return a.clearErrorLog()
 	case "U":

--- a/internal/app/keypress_actions.go
+++ b/internal/app/keypress_actions.go
@@ -74,14 +74,14 @@ func (a *App) updateSelectionCmd() tea.Cmd {
 	if len(a.filtered) == 0 || a.selectedIdx >= len(a.filtered) {
 		return nil
 	}
-	pkgName := a.filtered[a.selectedIdx].Name
-	cmds := []tea.Cmd{showPackageDetailCmd(pkgName)}
+	pkg := a.filtered[a.selectedIdx]
+	cmds := []tea.Cmd{showPackageDetailCmd(pkg.Name, pkg.Version)}
 	if a.fileListActive {
-		a.fileListPkg = pkgName
+		a.fileListPkg = pkg.Name
 		a.fileListItems = nil
 		a.fileListIdx = 0
 		a.fileListOffset = 0
-		cmds = append(cmds, loadFileListCmd(pkgName))
+		cmds = append(cmds, loadFileListCmd(pkg.Name))
 	}
 	return tea.Batch(cmds...)
 }

--- a/internal/app/keypress_filelist.go
+++ b/internal/app/keypress_filelist.go
@@ -64,7 +64,6 @@ func (a App) openFileList() (tea.Model, tea.Cmd) {
 	}
 	pkg := a.filtered[a.selectedIdx]
 	if a.fileListActive && a.fileListPkg == pkg.Name {
-		// Toggle off
 		a.fileListActive = false
 		a.fileListItems = nil
 		a.fileListPkg = ""

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -147,8 +147,6 @@ func (a App) onTabClick(x int) (tea.Model, tea.Cmd) {
 	return a, nil
 }
 
-// onHeaderClick maps an X coordinate to a column and toggles sorting.
-// contentWidth is the inner width of the panel containing the header.
 func (a App) onHeaderClick(x int, contentWidth int) (tea.Model, tea.Cmd) {
 	prefixW := 11
 	available := contentWidth - prefixW - 4
@@ -201,13 +199,9 @@ func (a App) onHeaderClick(x int, contentWidth int) (tea.Model, tea.Cmd) {
 	return a, a.updateSelectionCmd()
 }
 
-// onSideBySideClick handles mouse clicks in side-by-side layout.
-// In this layout the list panel starts at Y=1 (top border) and the list
-// items begin at Y=5 (border + title + header + separator).
 func (a App) onSideBySideClick(m tea.Mouse) (tea.Model, tea.Cmd) {
 	leftW := a.sideListWidth()
 
-	// Only handle clicks in the left (list) panel
 	if m.X >= leftW {
 		return a, nil
 	}
@@ -219,12 +213,10 @@ func (a App) onSideBySideClick(m tea.Mouse) (tea.Model, tea.Cmd) {
 	const sideListHeaderY = 8 // header row inside list panel
 	const sideListStartY = 10 // first package item row
 
-	// Click on search bar area → open search
 	if a.inSearchBox(y) && !a.searching {
 		return a.openSearch()
 	}
 
-	// Column header click → sort toggle
 	if y >= sideListHeaderY && y < sideListStartY {
 		return a.onHeaderClick(m.X-1, a.sideListWidth()-2) // -1 for left border
 	}

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -30,7 +30,7 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			}
 			return a.submitSearch()
 		}
-	}	
+	}
 
 	switch msg.(type) {
 	case tea.MouseWheelMsg:

--- a/internal/app/keypress_mouse.go
+++ b/internal/app/keypress_mouse.go
@@ -12,21 +12,28 @@ import (
 // Stacked layout: info panel (5 rows) sits above the list panel.
 // tabBar(1) + gap(1) + infoPanel(5) + gap(1) = 8, then border(1) + header(1) + sep(1).
 const (
-	packageListHeaderY = 8  
+	packageListHeaderY = 8
 	packageListStartY  = 10
 )
 
 func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
-	// Block mouse interactions while a modal dialog is open.
 	if a.importConfirm || a.removeConfirm || a.upgradeConfirm || a.versionView {
 		return a, nil
 	}
 	a.exportConfirm = false
 	m := msg.Mouse()
 
+	if a.searching {
+		if _, isClick := msg.(tea.MouseClickMsg); isClick {
+			if m.Y == a.searchBarY() {
+				return a, nil
+			}
+			return a.submitSearch()
+		}
+	}	
+
 	switch msg.(type) {
 	case tea.MouseWheelMsg:
-		// Scroll on tabs that use their own lists.
 		if a.activeTab == tabTransactions {
 			return a.onTransactionScroll(m.Button)
 		}
@@ -64,12 +71,10 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 
 		y := m.Y
 
-		// Click on tab bar (row 0) → switch tab
 		if y == 0 {
 			return a.onTabClick(m.X)
 		}
 
-		// Transactions/Repos/ErrorLog tabs: delegate to per-tab click handlers.
 		if a.activeTab == tabTransactions {
 			return a.onTransactionClick(m)
 		}
@@ -84,9 +89,8 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			return a.onSideBySideClick(m)
 		}
 
-		// Click on column header/separator area → toggle sort
 		if y >= packageListHeaderY && y < packageListStartY {
-			return a.onHeaderClick(m.X - 1) // -1 for left panel border
+			return a.onHeaderClick(m.X-1, a.width-2) // -1 for left panel border
 		}
 
 		if y == a.searchBarY() && !a.searching {
@@ -103,7 +107,6 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
-		// If clicking the already-selected row, toggle its selection (check/uncheck)
 		if idx == a.selectedIdx {
 			if a.selected == nil {
 				a.selected = make(map[string]bool)
@@ -118,7 +121,6 @@ func (a App) onMouseClick(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
-		// Move cursor to clicked row
 		a.selectedIdx = idx
 		a.adjustPackageScroll()
 		return a, a.updateSelectionCmd()
@@ -146,9 +148,10 @@ func (a App) onTabClick(x int) (tea.Model, tea.Cmd) {
 }
 
 // onHeaderClick maps an X coordinate to a column and toggles sorting.
-func (a App) onHeaderClick(x int) (tea.Model, tea.Cmd) {
+// contentWidth is the inner width of the panel containing the header.
+func (a App) onHeaderClick(x int, contentWidth int) (tea.Model, tea.Cmd) {
 	prefixW := 11
-	available := a.width - prefixW - 4
+	available := contentWidth - prefixW - 4
 	if available < 40 {
 		available = 40
 	}
@@ -217,13 +220,13 @@ func (a App) onSideBySideClick(m tea.Mouse) (tea.Model, tea.Cmd) {
 	const sideListStartY = 10 // first package item row
 
 	// Click on search bar area → open search
-	if y == a.searchBarY() && !a.searching {
+	if a.inSearchBox(y) && !a.searching {
 		return a.openSearch()
 	}
 
 	// Column header click → sort toggle
 	if y >= sideListHeaderY && y < sideListStartY {
-		return a.onHeaderClick(m.X - 1) // -1 for left border
+		return a.onHeaderClick(m.X-1, a.sideListWidth()-2) // -1 for left border
 	}
 
 	row := y - sideListStartY

--- a/internal/app/keypress_portpkg.go
+++ b/internal/app/keypress_portpkg.go
@@ -97,7 +97,6 @@ func (a App) onImportFinished(msg importFinishedMsg) (tea.Model, tea.Cmd) {
 		a.status = ui.SuccessStyle.Render("\u2714 Import file contains no packages.")
 		return a, clearStatusAfter(5 * time.Second)
 	}
-	// Filter out packages that are already installed
 	var toInstall []string
 	for _, name := range msg.names {
 		if idx, ok := a.pkgIndex[name]; ok && a.allPackages[idx].Installed {

--- a/internal/app/keypress_repo_filter.go
+++ b/internal/app/keypress_repo_filter.go
@@ -1,0 +1,253 @@
+package app
+
+import (
+	"sort"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mexirica/aptui/internal/model"
+)
+
+func (a App) onRepoFilterKeypress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		return a, tea.Quit
+	case "esc":
+		a.repoFilterView = false
+		a.repoFilterItems = nil
+		return a, nil
+	case "j", "down":
+		if a.repoFilterIdx < len(a.repoFilterItems)-1 {
+			a.repoFilterIdx++
+			a.adjustRepoFilterScroll()
+		}
+		return a, nil
+	case "k", "up":
+		if a.repoFilterIdx > 0 {
+			a.repoFilterIdx--
+			a.adjustRepoFilterScroll()
+		}
+		return a, nil
+	case "ctrl+d", "pgdown":
+		a.repoFilterIdx += a.repoFilterListHeight()
+		if a.repoFilterIdx >= len(a.repoFilterItems) {
+			a.repoFilterIdx = len(a.repoFilterItems) - 1
+		}
+		a.adjustRepoFilterScroll()
+		return a, nil
+	case "ctrl+u", "pgup":
+		a.repoFilterIdx -= a.repoFilterListHeight()
+		if a.repoFilterIdx < 0 {
+			a.repoFilterIdx = 0
+		}
+		a.adjustRepoFilterScroll()
+		return a, nil
+	case "enter":
+		return a.applyRepoFilter()
+	}
+	return a, nil
+}
+
+func (a App) applyRepoFilter() (tea.Model, tea.Cmd) {
+	if len(a.repoFilterItems) == 0 || a.repoFilterIdx >= len(a.repoFilterItems) {
+		a.repoFilterView = false
+		return a, nil
+	}
+	selected := a.repoFilterItems[a.repoFilterIdx]
+	a.repoFilterView = false
+	a.repoFilterItems = nil
+
+	if selected == "" {
+		a.filterQuery = removeRepoToken(a.filterQuery)
+	} else {
+		a.filterQuery = replaceRepoToken(a.filterQuery, selected)
+	}
+
+	a.applyFilter(false)
+	a.status = ""
+	return a, a.updateSelectionCmd()
+}
+
+func (a App) openRepoFilter() (tea.Model, tea.Cmd) {
+	repos := reposFromPackages(a.allPackages)
+	if len(repos) == 0 {
+		a.status = "No repository metadata available. Run apt update first."
+		return a, nil
+	}
+
+	items := append([]string{""}, repos...)
+
+	a.repoFilterItems = items
+	a.repoFilterIdx = 0
+	a.repoFilterOffset = 0
+
+	if current := currentRepoFilter(a.filterQuery); current != "" {
+		for i, r := range items {
+			if r == current {
+				a.repoFilterIdx = i
+				break
+			}
+		}
+	}
+
+	a.repoFilterView = true
+	return a, nil
+}
+
+// reposFromPackages extracts sorted unique individual origins from all packages.
+func reposFromPackages(pkgs []model.Package) []string {
+	seen := make(map[string]bool)
+	for _, p := range pkgs {
+		if p.Origin == "" {
+			continue
+		}
+		for _, part := range strings.Split(p.Origin, "; ") {
+			part = strings.TrimSpace(part)
+			if part != "" && !seen[part] {
+				seen[part] = true
+			}
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for r := range seen {
+		result = append(result, r)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// currentRepoFilter extracts the repo: value from a filter query string,
+// handling both plain and quoted forms: repo:foo or repo:"foo bar".
+func currentRepoFilter(q string) string {
+	for _, t := range tokenizeQuery(q) {
+		lower := strings.ToLower(t)
+		if strings.HasPrefix(lower, "repo:") {
+			return t[5:]
+		}
+		if strings.HasPrefix(lower, "origin:") {
+			return t[7:]
+		}
+	}
+	return ""
+}
+
+// tokenizeQuery splits a query the same way the filter parser does,
+// preserving quoted values as single tokens (without the quotes).
+func tokenizeQuery(s string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inQuote := false
+	quoteChar := rune(0)
+	for _, r := range s {
+		if inQuote {
+			if r == quoteChar {
+				inQuote = false
+			} else {
+				cur.WriteRune(r)
+			}
+		} else if r == '"' || r == '\'' {
+			inQuote = true
+			quoteChar = r
+		} else if r == ' ' || r == '\t' {
+			if cur.Len() > 0 {
+				tokens = append(tokens, cur.String())
+				cur.Reset()
+			}
+		} else {
+			cur.WriteRune(r)
+		}
+	}
+	if cur.Len() > 0 {
+		tokens = append(tokens, cur.String())
+	}
+	return tokens
+}
+
+// splitQueryTokens splits q on whitespace, treating quoted strings as single tokens.
+// Unlike strings.Fields, a value like repo:"foo bar" or repo:'foo bar' is kept as one token.
+func splitQueryTokens(q string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inQuote := false
+	quoteChar := rune(0)
+	for _, r := range q {
+		if inQuote {
+			cur.WriteRune(r)
+			if r == quoteChar {
+				inQuote = false
+			}
+		} else if r == '"' || r == '\'' {
+			inQuote = true
+			quoteChar = r
+			cur.WriteRune(r)
+		} else if r == ' ' || r == '\t' {
+			if cur.Len() > 0 {
+				tokens = append(tokens, cur.String())
+				cur.Reset()
+			}
+		} else {
+			cur.WriteRune(r)
+		}
+	}
+	if cur.Len() > 0 {
+		tokens = append(tokens, cur.String())
+	}
+	return tokens
+}
+
+// removeRepoToken strips repo:/origin: tokens from q.
+func removeRepoToken(q string) string {
+	var out []string
+	for _, t := range splitQueryTokens(q) {
+		lower := strings.ToLower(t)
+		if !strings.HasPrefix(lower, "repo:") && !strings.HasPrefix(lower, "origin:") {
+			out = append(out, t)
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+// replaceRepoToken replaces any existing repo:/origin: token with repo:"value",
+// or appends one. Quotes are added only when the value contains spaces.
+func replaceRepoToken(q string, repo string) string {
+	var quoted string
+	if strings.ContainsRune(repo, ' ') {
+		quoted = `repo:"` + repo + `"`
+	} else {
+		quoted = "repo:" + repo
+	}
+
+	tokens := splitQueryTokens(q)
+	found := false
+	for i, t := range tokens {
+		lower := strings.ToLower(t)
+		if strings.HasPrefix(lower, "repo:") || strings.HasPrefix(lower, "origin:") {
+			tokens[i] = quoted
+			found = true
+			break
+		}
+	}
+	if !found {
+		tokens = append(tokens, quoted)
+	}
+	return strings.Join(tokens, " ")
+}
+
+func (a *App) adjustRepoFilterScroll() {
+	h := a.repoFilterListHeight()
+	if a.repoFilterIdx < a.repoFilterOffset {
+		a.repoFilterOffset = a.repoFilterIdx
+	}
+	if a.repoFilterIdx >= a.repoFilterOffset+h {
+		a.repoFilterOffset = a.repoFilterIdx - h + 1
+	}
+}
+
+func (a App) repoFilterListHeight() int {
+	h := a.height - 10
+	if h < 3 {
+		h = 3
+	}
+	return h
+}

--- a/internal/app/keypress_version.go
+++ b/internal/app/keypress_version.go
@@ -118,7 +118,6 @@ func (a App) onVersionListLoaded(msg versionListMsg) (tea.Model, tea.Cmd) {
 		a.status = fmt.Sprintf("Only 1 version available for %s in configured repositories.", msg.name)
 		return a, nil
 	}
-	// Only now open the version view
 	a.versionView = true
 	a.versionItems = msg.versions
 	a.versionPkg = msg.name

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -342,6 +342,8 @@ func (a App) onSearchResultLoaded(msg searchResultMsg) (tea.Model, tea.Cmd) {
 			msg.pkgs[i].Section = inst.Section
 			msg.pkgs[i].Architecture = inst.Architecture
 			msg.pkgs[i].Origin = inst.Origin
+			msg.pkgs[i].ManuallyInstalled = inst.ManuallyInstalled
+			msg.pkgs[i].Essential = a.essentialSet[msg.pkgs[i].Name]
 			if msg.pkgs[i].Description == "" {
 				msg.pkgs[i].Description = inst.Description
 			}
@@ -407,6 +409,9 @@ func (a App) onPackageDetailLoaded(msg detailLoadedMsg) (tea.Model, tea.Cmd) {
 				pi.Origins = existing.Origins
 			}
 			a.infoCache[msg.name] = pi
+			if pi.Essential {
+				a.essentialSet[msg.name] = true
+			}
 			for i := range a.filtered {
 				if a.filtered[i].Name == msg.name {
 					if a.filtered[i].Version == "" && a.filtered[i].NewVersion == "" {
@@ -423,6 +428,9 @@ func (a App) onPackageDetailLoaded(msg detailLoadedMsg) (tea.Model, tea.Cmd) {
 					}
 					if a.filtered[i].Description == "" {
 						a.filtered[i].Description = pi.Description
+					}
+					if pi.Essential {
+						a.filtered[i].Essential = true
 					}
 					break
 				}
@@ -442,6 +450,9 @@ func (a App) onPackageDetailLoaded(msg detailLoadedMsg) (tea.Model, tea.Cmd) {
 				}
 				if a.allPackages[idx].Description == "" {
 					a.allPackages[idx].Description = pi.Description
+				}
+				if pi.Essential {
+					a.allPackages[idx].Essential = true
 				}
 			}
 		}

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/spinner"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/mexirica/aptui/internal/apt"
 	"github.com/mexirica/aptui/internal/fetch"
+	"github.com/mexirica/aptui/internal/filter"
 	"github.com/mexirica/aptui/internal/history"
 	"github.com/mexirica/aptui/internal/model"
 	"github.com/mexirica/aptui/internal/ui"
@@ -112,6 +114,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.versionView {
 			return a.onVersionKeypress(msg)
 		}
+		if a.repoFilterView {
+			return a.onRepoFilterKeypress(msg)
+		}
 		if a.fetchView {
 			return a.onFetchKeypress(msg)
 		}
@@ -194,12 +199,19 @@ func (a App) onAllPackagesLoaded(msg allPackagesMsg) (tea.Model, tea.Cmd) {
 			if p.Description == "" {
 				p.Description = info.Description
 			}
+			if len(info.Origins) > 0 {
+				p.Origin = strings.Join(info.Origins, "; ")
+			}
 		}
 		all = append(all, p)
 		seen[p.Name] = true
 	}
 	for name, info := range msg.bulkInfo {
 		if !seen[name] {
+			var origin string
+			if len(info.Origins) > 0 {
+				origin = strings.Join(info.Origins, "; ")
+			}
 			pkg := model.Package{
 				Name:         name,
 				Installed:    false,
@@ -210,6 +222,7 @@ func (a App) onAllPackagesLoaded(msg allPackagesMsg) (tea.Model, tea.Cmd) {
 				Pinned:       a.pinnedSet[name],
 				Essential:    info.Essential,
 				Description:  info.Description,
+				Origin:       origin,
 			}
 			all = append(all, pkg)
 			seen[name] = true
@@ -328,6 +341,7 @@ func (a App) onSearchResultLoaded(msg searchResultMsg) (tea.Model, tea.Cmd) {
 			msg.pkgs[i].Size = inst.Size
 			msg.pkgs[i].Section = inst.Section
 			msg.pkgs[i].Architecture = inst.Architecture
+			msg.pkgs[i].Origin = inst.Origin
 			if msg.pkgs[i].Description == "" {
 				msg.pkgs[i].Description = inst.Description
 			}
@@ -339,12 +353,39 @@ func (a App) onSearchResultLoaded(msg searchResultMsg) (tea.Model, tea.Cmd) {
 			if msg.pkgs[i].Description == "" {
 				msg.pkgs[i].Description = info.Description
 			}
+			if len(info.Origins) > 0 {
+				msg.pkgs[i].Origin = strings.Join(info.Origins, "; ")
+			}
 		}
 	}
-	a.filtered = msg.pkgs
+	// Apply repo/origin filter from the query: apt-cache returns unfiltered results
+	// so we must post-filter here when the query contains a repo: or origin: clause.
+	af := filter.Parse(a.filterQuery)
+	results := msg.pkgs
+	if af.Origin != "" {
+		filtered := results[:0]
+		for _, p := range results {
+			if af.Match(filter.PackageData{
+				Name:         p.Name,
+				Version:      p.Version,
+				NewVersion:   p.NewVersion,
+				Size:         p.Size,
+				Description:  p.Description,
+				Installed:    p.Installed,
+				Upgradable:   p.Upgradable,
+				Section:      p.Section,
+				Architecture: p.Architecture,
+				Origin:       p.Origin,
+			}) {
+				filtered = append(filtered, p)
+			}
+		}
+		results = filtered
+	}
+	a.filtered = results
 	a.selectedIdx = 0
 	a.scrollOffset = 0
-	a.status = fmt.Sprintf("%d results for '%s'", len(msg.pkgs), a.filterQuery)
+	a.status = fmt.Sprintf("%d results for '%s'", len(results), a.filterQuery)
 	if len(a.filtered) == 0 {
 		a.detailInfo = ""
 		a.detailName = ""
@@ -360,6 +401,11 @@ func (a App) onPackageDetailLoaded(msg detailLoadedMsg) (tea.Model, tea.Cmd) {
 		a.detailInfo = msg.info
 		pi := apt.ParseShowEntry(msg.info)
 		if pi.Version != "" || pi.Size != "" {
+			// Preserve Origins loaded from bulk package files; ParseShowEntry
+			// has no access to the apt lists so it always returns an empty slice.
+			if existing, ok := a.infoCache[msg.name]; ok && len(existing.Origins) > 0 {
+				pi.Origins = existing.Origins
+			}
 			a.infoCache[msg.name] = pi
 			for i := range a.filtered {
 				if a.filtered[i].Name == msg.name {

--- a/internal/app/view.go
+++ b/internal/app/view.go
@@ -40,6 +40,10 @@ func (a App) View() tea.View {
 		return a.newView(a.renderVersionView(w))
 	}
 
+	if a.repoFilterView {
+		return a.newView(a.renderRepoFilterView(w))
+	}
+
 	tabBar := a.renderTabBar()
 
 	if a.activeTab == tabRepos {
@@ -400,15 +404,9 @@ func (a App) renderStacked(w int, tabBar string) string {
 	if a.importingPath {
 		searchContent = " Import path: " + a.importInput.View()
 	} else if a.searching {
-		searchContent = " " + a.searchInput.View()
+		searchContent = renderSearchBar(a.searchInput.View())
 	} else {
-		if a.filterQuery != "" {
-			promptStyle := lipgloss.NewStyle().Foreground(ui.ColorPrimary).Bold(true)
-			queryStyle := lipgloss.NewStyle().Foreground(ui.ColorDetailValue)
-			searchContent = " " + promptStyle.Render("❯ ") + queryStyle.Render(a.filterQuery)
-		} else {
-			searchContent = lipgloss.NewStyle().Foreground(ui.ColorMuted).Render(" Press / to search or filter...")
-		}
+		searchContent = renderSearchBar(a.filterQuery)
 	}
 
 	statusContent := a.status
@@ -660,6 +658,44 @@ func (a App) renderVersionView(w int) string {
 	return panel + strings.Repeat("\n", gap) + statusBarView
 }
 
+func (a App) renderRepoFilterView(w int) string {
+	if w < 20 {
+		w = 20
+	}
+	if a.height < 10 {
+		return "Terminal too small"
+	}
+
+	counterStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
+	statusBar := lipgloss.JoinVertical(lipgloss.Left,
+		components.RenderStatusBar(a.status, w),
+		counterStyle.Render(fmt.Sprintf("%d repositories | enter filter | esc cancel ", len(a.repoFilterItems)-1)),
+	)
+	statusBarLines := strings.Count(statusBar, "\n") + 1
+
+	panelH := a.height - 2 - statusBarLines
+	if panelH < 7 {
+		panelH = 7
+	}
+	innerH := panelH - 2
+
+	maxVisible := innerH - 4
+	if maxVisible < 3 {
+		maxVisible = 3
+	}
+
+	activeFilter := currentRepoFilter(a.filterQuery)
+	listContent := components.RenderRepoList(a.repoFilterItems, a.repoFilterIdx, a.repoFilterOffset, maxVisible, w-4, activeFilter)
+	countText := lipgloss.NewStyle().Foreground(ui.ColorSubtle).Render(fmt.Sprintf("%d", len(a.repoFilterItems)-1))
+	panel := renderTitledPanel("Repository Filter", countText, listContent, w, panelH)
+
+	gap := a.height - strings.Count(panel, "\n") - statusBarLines - 1
+	if gap < 0 {
+		gap = 0
+	}
+	return panel + strings.Repeat("\n", gap) + statusBar
+}
+
 func (a App) renderTransactionView(w int, tabBar string) string {
 	var statusParts []string
 	counterStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
@@ -851,15 +887,9 @@ func (a App) renderSideBySide(w int, tabBar string) string {
 	if a.importingPath {
 		searchContent = " Import path: " + a.importInput.View()
 	} else if a.searching {
-		searchContent = " " + a.searchInput.View()
+		searchContent = renderSearchBar(a.searchInput.View())
 	} else {
-		if a.filterQuery != "" {
-			promptStyle := lipgloss.NewStyle().Foreground(ui.ColorPrimary).Bold(true)
-			queryStyle := lipgloss.NewStyle().Foreground(ui.ColorDetailValue)
-			searchContent = " " + promptStyle.Render("❯ ") + queryStyle.Render(a.filterQuery)
-		} else {
-			searchContent = lipgloss.NewStyle().Foreground(ui.ColorMuted).Render(" Press / to search or filter...")
-		}
+		searchContent = renderSearchBar(a.filterQuery)
 	}
 	searchPanel := renderTitledPanel("Search / Filter", "", searchContent, leftW, infoRowH)
 
@@ -897,6 +927,23 @@ func (a App) renderSideBySide(w int, tabBar string) string {
 	}
 
 	return page
+}
+
+// renderSearchBar renders a unified single-line search/filter bar.
+// inputView may be a plain filterQuery string or a textinput.View() (contains ANSI escapes when active).
+func renderSearchBar(inputView string) string {
+	promptStyle := lipgloss.NewStyle().Foreground(ui.ColorPrimary).Bold(true)
+	queryStyle := lipgloss.NewStyle().Foreground(ui.ColorDetailValue)
+	mutedStyle := lipgloss.NewStyle().Foreground(ui.ColorMuted)
+
+	if inputView == "" {
+		return mutedStyle.Render(" Press / to filter, o for repo...")
+	}
+	// textinput.View() contains ANSI escape sequences — render as-is
+	if strings.Contains(inputView, "\x1b") {
+		return " " + inputView
+	}
+	return " " + promptStyle.Render("❯ ") + queryStyle.Render(inputView)
 }
 
 // renderTitledPanel renders a bordered panel with the title embedded in the

--- a/internal/apt/apt_test.go
+++ b/internal/apt/apt_test.go
@@ -307,7 +307,7 @@ func TestParsePackageFileDescription(t *testing.T) {
 		t.Fatal(err)
 	}
 	info := make(map[string]PackageInfo)
-	parsePackageFile(path, info)
+	parsePackageFile(path, info, "test/origin")
 
 	pi, ok := info["testpkg"]
 	if !ok {
@@ -358,7 +358,7 @@ func TestParsePackageFileEssential(t *testing.T) {
 		t.Fatal(err)
 	}
 	info := make(map[string]PackageInfo)
-	parsePackageFile(path, info)
+	parsePackageFile(path, info, "test/origin")
 
 	pi, ok := info["base-files"]
 	if !ok {
@@ -1212,7 +1212,7 @@ func TestParsePackageFileEmptyFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	info := make(map[string]PackageInfo)
-	parsePackageFile(path, info)
+	parsePackageFile(path, info, "test/origin")
 	if len(info) != 0 {
 		t.Errorf("expected 0 entries from empty file, got %d", len(info))
 	}
@@ -1220,7 +1220,7 @@ func TestParsePackageFileEmptyFile(t *testing.T) {
 
 func TestParsePackageFileNonexistent(t *testing.T) {
 	info := make(map[string]PackageInfo)
-	parsePackageFile("/nonexistent/path/Packages", info)
+	parsePackageFile("/nonexistent/path/Packages", info, "test/origin")
 	if len(info) != 0 {
 		t.Errorf("expected 0 entries from nonexistent file, got %d", len(info))
 	}
@@ -1254,7 +1254,7 @@ Description: transfer tool
 		t.Fatal(err)
 	}
 	info := make(map[string]PackageInfo)
-	parsePackageFile(path, info)
+	parsePackageFile(path, info, "test/origin")
 	if len(info) != 3 {
 		t.Fatalf("expected 3 entries, got %d", len(info))
 	}

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -28,17 +28,40 @@ func LoadAllAvailableInfo() map[string]PackageInfo {
 	info := make(map[string]PackageInfo, 100000)
 
 	for _, f := range files {
-		parsePackageFile(f, info)
+		origin := originFromListFilename(f)
+		parsePackageFile(f, info, origin)
 	}
 
 	return info
+}
+
+// originFromListFilename extracts a human-readable repository origin from an
+// apt lists filename such as
+// "/var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_noble_main_binary-amd64_Packages".
+func originFromListFilename(path string) string {
+	base := filepath.Base(path)
+	// Remove _Packages suffix
+	base = strings.TrimSuffix(base, "_Packages")
+	// Remove _binary-<arch> suffix
+	if idx := strings.LastIndex(base, "_binary-"); idx > 0 {
+		base = base[:idx]
+	}
+	// Split on _dists_ to separate URL from codename/component
+	if parts := strings.SplitN(base, "_dists_", 2); len(parts) == 2 {
+		url := strings.ReplaceAll(parts[0], "_", "/")
+		comp := strings.ReplaceAll(parts[1], "_", "/")
+		return url + " " + comp
+	}
+	// Flat repo: just convert underscores to slashes
+	return strings.ReplaceAll(base, "_", "/")
 }
 
 // parsePackageFile parses a single *_Packages file and merges entries into info.
 // Later files overwrite earlier ones; note that filepath.Glob returns files in
 // lexicographic order, which may not exactly match apt pin priorities —
 // this is a known simplification that works for typical setups.
-func parsePackageFile(path string, info map[string]PackageInfo) {
+// The origin parameter is appended to each package's Origins list.
+func parsePackageFile(path string, info map[string]PackageInfo, origin string) {
 	file, err := os.Open(path)
 	if err != nil {
 		return
@@ -55,6 +78,16 @@ func parsePackageFile(path string, info map[string]PackageInfo) {
 
 	flush := func() {
 		if curPkg != "" {
+			existing, exists := info[curPkg]
+			origins := []string{origin}
+			if exists && existing.Version == curVer {
+				// Same version in multiple components: merge origins
+				for _, o := range existing.Origins {
+					if o != origin {
+						origins = append(origins, o)
+					}
+				}
+			}
 			info[curPkg] = PackageInfo{
 				Version:      curVer,
 				Size:         formatSize(curSize),
@@ -62,6 +95,7 @@ func parsePackageFile(path string, info map[string]PackageInfo) {
 				Architecture: curArch,
 				Description:  curDesc,
 				Essential:    curEssential,
+				Origins:      origins,
 			}
 		}
 		curPkg, curVer, curSize, curSection, curArch, curDesc = "", "", "", "", "", ""
@@ -214,6 +248,7 @@ type VersionInfo struct {
 // ListVersions returns all available versions for a package using apt-cache policy.
 func ListVersions(name string) ([]VersionInfo, error) {
 	cmd := exec.Command("apt-cache", "policy", name)
+	cmd.Env = append(os.Environ(), "LANG=C", "LC_ALL=C")
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out
@@ -562,16 +597,6 @@ func ListAllNames() ([]string, error) {
 	return names, nil
 }
 
-func IsInstalled(name string) bool {
-	cmd := exec.Command("dpkg-query", "-W", "-f=${Status}", name)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	if err := cmd.Run(); err != nil {
-		return false
-	}
-	return strings.Contains(out.String(), "install ok installed")
-}
-
 // PPA represents a repository configured on the system.
 // When IsPPA is true it is a Launchpad PPA; otherwise it is a standard
 // Debian/Ubuntu repository entry.
@@ -581,86 +606,6 @@ type PPA struct {
 	File    string // source file path
 	Enabled bool
 	IsPPA   bool
-}
-
-// ListPPAs scans /etc/apt/sources.list.d/ for PPA entries.
-func ListPPAs() ([]PPA, error) {
-	dir := platform.AptPath("sources.list.d")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, fmt.Errorf("read sources.list.d: %w", err)
-	}
-
-	var ppas []PPA
-	seen := make(map[string]bool)
-
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		path := dir + "/" + entry.Name()
-
-		if strings.HasSuffix(entry.Name(), ".list") {
-			data, err := os.ReadFile(path)
-			if err != nil {
-				continue
-			}
-			for _, line := range strings.Split(string(data), "\n") {
-				line = strings.TrimSpace(line)
-				enabled := true
-				if strings.HasPrefix(line, "#") {
-					enabled = false
-					line = strings.TrimSpace(strings.TrimPrefix(line, "#"))
-				}
-				if !strings.HasPrefix(line, "deb") {
-					continue
-				}
-				if !strings.Contains(line, "ppa.launchpad.net") && !strings.Contains(line, "ppa.launchpadcontent.net") {
-					continue
-				}
-				ppaName := extractPPAName(line)
-				if ppaName != "" && !seen[ppaName] {
-					seen[ppaName] = true
-					ppas = append(ppas, PPA{
-						Name:    ppaName,
-						URL:     extractPPAURL(line),
-						File:    path,
-						Enabled: enabled,
-						IsPPA:   true,
-					})
-				}
-			}
-		}
-
-		if strings.HasSuffix(entry.Name(), ".sources") {
-			data, err := os.ReadFile(path)
-			if err != nil {
-				continue
-			}
-			content := string(data)
-			if !strings.Contains(content, "ppa.launchpad.net") && !strings.Contains(content, "ppa.launchpadcontent.net") {
-				continue
-			}
-			for _, stanza := range splitDEB822Stanzas(content) {
-				if stanza.URI == "" {
-					continue
-				}
-				ppaName := extractPPAName(stanza.URI)
-				if ppaName != "" && !seen[ppaName] {
-					seen[ppaName] = true
-					ppas = append(ppas, PPA{
-						Name:    ppaName,
-						URL:     stanza.URI,
-						File:    path,
-						Enabled: stanza.Enabled,
-						IsPPA:   true,
-					})
-				}
-			}
-		}
-	}
-
-	return ppas, nil
 }
 
 // ListAllRepos scans /etc/apt/sources.list and /etc/apt/sources.list.d/ for all repository entries,
@@ -1095,6 +1040,7 @@ type PackageInfo struct {
 	Architecture string
 	Description  string
 	Essential    bool
+	Origins      []string // repository origins that provide this package
 }
 
 // ParseShowEntry parses a single apt-cache show output and returns PackageInfo.

--- a/internal/apt/client.go
+++ b/internal/apt/client.go
@@ -188,8 +188,12 @@ func SearchPackages(query string) ([]model.Package, error) {
 	return parseSearchOutput(out.String()), nil
 }
 
-func ShowPackage(name string) (string, error) {
-	cmd := exec.Command("apt-cache", "show", name)
+func ShowPackage(name string, version string) (string, error) {
+	pkgArg := name
+	if version != "" {
+		pkgArg = name + "=" + version
+	}
+	cmd := exec.Command("apt-cache", "show", pkgArg)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -69,6 +69,7 @@ type Filter struct {
 	Name         string     // contains (case-insensitive)
 	Version      string     // contains (case-insensitive)
 	Description  string     // contains (case-insensitive)
+	Origin       string     // contains (case-insensitive) — matches repository origin
 	OrderBy      SortColumn // column to sort by
 	OrderDesc    bool       // true for descending order
 	FreeText     string     // unrecognized tokens joined for fuzzy search
@@ -84,14 +85,15 @@ func (f Filter) IsEmpty() bool {
 		f.Name == "" &&
 		f.Version == "" &&
 		f.Description == "" &&
+		f.Origin == "" &&
 		f.OrderBy == SortNone &&
 		f.FreeText == ""
 }
 
-// NeedsMetadata returns true if the filter uses fields (Section, Architecture, Size)
+// NeedsMetadata returns true if the filter uses fields (Section, Architecture, Size, Origin)
 // that require package metadata from apt-cache show.
 func (f Filter) NeedsMetadata() bool {
-	return f.Section != "" || f.Architecture != "" || f.Size != nil
+	return f.Section != "" || f.Architecture != "" || f.Size != nil || f.Origin != ""
 }
 
 // PackageData is the minimal interface a package must expose for filtering.
@@ -105,6 +107,7 @@ type PackageData struct {
 	Upgradable   bool
 	Section      string
 	Architecture string
+	Origin       string // repository origin (may contain multiple origins separated by "; ")
 }
 
 // Match returns true if the package satisfies all filter criteria.
@@ -178,6 +181,9 @@ func (f Filter) matchMetadata(p PackageData) bool {
 				return false
 			}
 		}
+	}
+	if f.Origin != "" && !containsFold(p.Origin, f.Origin) {
+		return false
 	}
 	return true
 }
@@ -254,6 +260,8 @@ func Parse(query string) Filter {
 				f.Version = val
 			case "desc", "description":
 				f.Description = val
+			case "repo", "origin":
+				f.Origin = val
 			case "size":
 				// size:>10MB variant
 				if sf := parseSizeExpr(val); sf != nil {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -15,4 +15,5 @@ type Package struct {
 	Pinned            bool
 	Essential         bool
 	ManuallyInstalled bool
+	Origin            string // primary repository origin
 }

--- a/internal/ui/components/components_test.go
+++ b/internal/ui/components/components_test.go
@@ -269,18 +269,6 @@ func TestRenderPackageListHeldBadge(t *testing.T) {
 	}
 }
 
-func TestRenderPackageListEssentialBadge(t *testing.T) {
-	pkgs := []model.Package{
-		{Name: "base-files", Version: "12", Installed: true, Essential: true},
-		{Name: "vim", Version: "8.2", Installed: true},
-	}
-
-	result := RenderPackageList(pkgs, 0, 0, 10, 120, nil)
-	if !strings.Contains(result, "◈") {
-		t.Error("essential package should show shield badge")
-	}
-}
-
 func TestWrapText(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/ui/components/packagedetail.go
+++ b/internal/ui/components/packagedetail.go
@@ -31,6 +31,7 @@ var displayFields = []string{
 	"Breaks",
 	"Replaces",
 	"Manual-Installed",
+	"Essential",
 	"Description",
 	"Homepage",
 }

--- a/internal/ui/components/packagedetail.go
+++ b/internal/ui/components/packagedetail.go
@@ -18,6 +18,7 @@ var displayFields = []string{
 	"Priority",
 	"Section",
 	"Source",
+	"Origins",
 	"Installed-Size",
 	"Maintainer",
 	"Architecture",

--- a/internal/ui/components/packagelist.go
+++ b/internal/ui/components/packagelist.go
@@ -24,7 +24,7 @@ func RenderPackageList(packages []model.Package, selected int, offset int, maxVi
 	selCheckStyle := lipgloss.NewStyle().Foreground(ui.ColorAccent).Bold(true)
 	selUncheckStyle := lipgloss.NewStyle().Foreground(ui.ColorUncheck)
 
-	// prefix takes: cursor(3) + space(1) + selMarker(3) + space(1) + badge(26) + space(1) = ~11
+	// prefix takes: cursor(3) + space(1) + selMarker(3) + space(1) + badge(2) + space(1) = 11
 	prefixW := 11
 	available := width - prefixW - 4 // 4 for column gaps (2 between each)
 	if available < 40 {
@@ -138,26 +138,16 @@ func RenderPackageList(packages []model.Package, selected int, offset int, maxVi
 
 		name := pkg.Name
 		isPinned := pkg.Pinned
-		pinnedSuffix := ""
-		essentialSuffix := ""
-		manualSuffix := ""
 		maxLen := colName
 		if isPinned {
-			pinnedSuffix = " ★"
 			maxLen -= 2 // reserve space for " ★"
-		}
-		if pkg.Essential {
-			essentialSuffix = " ◈"
-			maxLen -= 2 // reserve space for " ◈"
-		}
-		if pkg.ManuallyInstalled {
-			manualSuffix = " ᴹ"
-			maxLen -= 2 // reserve space for " ᴹ"
 		}
 		if len(name) > maxLen && maxLen > 0 {
 			name = name[:maxLen-1] + "…"
 		}
-		name += pinnedSuffix + essentialSuffix + manualSuffix
+		if isPinned {
+			name += " ★"
+		}
 
 		version := pkg.Version
 		if version == "" && pkg.NewVersion != "" {

--- a/internal/ui/components/packagelist.go
+++ b/internal/ui/components/packagelist.go
@@ -160,7 +160,7 @@ func RenderPackageList(packages []model.Package, selected int, offset int, maxVi
 		name += pinnedSuffix + essentialSuffix + manualSuffix
 
 		version := pkg.Version
-		if pkg.NewVersion != "" {
+		if version == "" && pkg.NewVersion != "" {
 			version = pkg.NewVersion
 		}
 		if version == "" {

--- a/internal/ui/components/repolist.go
+++ b/internal/ui/components/repolist.go
@@ -1,0 +1,86 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/mexirica/aptui/internal/ui"
+)
+
+// RenderRepoList renders the repository filter overlay.
+func RenderRepoList(items []string, selected int, offset int, maxVisible int, width int, activeFilter string) string {
+	if width < 20 {
+		width = 20
+	}
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.ColorColumnHeader)
+	cursorSt := lipgloss.NewStyle().Foreground(ui.ColorPrimary).Bold(true)
+	activeStyle := lipgloss.NewStyle().Foreground(ui.ColorSuccess).Bold(true)
+	dimStyle := lipgloss.NewStyle().Foreground(ui.ColorSecondary)
+	itemStyle := lipgloss.NewStyle().Foreground(ui.ColorWhite)
+	clearStyle := lipgloss.NewStyle().Foreground(ui.ColorWarning)
+
+	if len(items) == 0 {
+		return lipgloss.NewStyle().Foreground(ui.ColorSecondary).
+			Render("\n  No repository metadata available.\n" +
+				"  Tip: run apt update to refresh package lists.\n")
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("  %s\n",
+		headerStyle.Render("Filter by repository")))
+	b.WriteString(fmt.Sprintf("  %s\n\n",
+		dimStyle.Render("(enter to filter, esc to cancel)")))
+
+	b.WriteString("    " + headerStyle.Render("Repository") + "\n")
+
+	end := offset + maxVisible
+	if end > len(items) {
+		end = len(items)
+	}
+
+	for i := offset; i < end; i++ {
+		label := items[i]
+		isClear := label == ""
+
+		// Truncate if too long
+		maxLen := width - 8
+		if maxLen < 10 {
+			maxLen = 10
+		}
+		display := label
+		if isClear {
+			display = "  [Clear repo filter]"
+		} else if len([]rune(display)) > maxLen {
+			display = string([]rune(display)[:maxLen-1]) + "…"
+		}
+
+		isActive := !isClear && label == activeFilter
+
+		if i == selected {
+			cursor := cursorSt.Render("▌ ")
+			var rendered string
+			if isClear {
+				rendered = clearStyle.Render(display)
+			} else if isActive {
+				rendered = activeStyle.Render("● " + display)
+			} else {
+				rendered = itemStyle.Render("  " + display)
+			}
+			b.WriteString(fmt.Sprintf("  %s%s\n", cursor, rendered))
+		} else {
+			var rendered string
+			if isClear {
+				rendered = dimStyle.Render(display)
+			} else if isActive {
+				rendered = activeStyle.Render("● " + display)
+			} else {
+				rendered = dimStyle.Render("  " + display)
+			}
+			b.WriteString(fmt.Sprintf("    %s\n", rendered))
+		}
+	}
+
+	return b.String()
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds repository origin filtering to aptui 0.9, including a new `repo:`/`origin:` filter token, an origin dropdown overlay (`o` key), origin tracking extracted from APT list filenames, version-specific `apt-cache show` calls, and Essential-flag propagation into the detail panel.

- New `keypress_repo_filter.go` and `repolist.go` implement the repo-origin dropdown; `originFromListFilename` derives human-readable origins from `/var/lib/apt/lists/` filenames and merges them into `PackageInfo.Origins`.
- `ShowPackage` now passes `name=version` to `apt-cache show` so the detail panel reflects the exact selected version; `ListVersions` gains `LANG=C` for reliable output parsing.
- Package list badges for Essential and ManuallyInstalled are removed from the list rows (kept in the detail panel); the pinned ★ badge is retained.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the two mouse-blocking and scroll-offset issues; the core origin-filtering logic is correct.

Mouse events are not blocked while the repo-filter overlay is active: scroll wheel events scroll the underlying package list and clicks can change selection or switch tabs while the dropdown is displayed. Separately, reopening the dropdown when a repo: filter is already active restores the cursor index but not the scroll offset, so the highlighted row is invisible if the matching origin is not on the first page.

internal/app/update.go (mouse-event guard) and internal/app/keypress_repo_filter.go (initial scroll adjustment in openRepoFilter)

<sub>Reviews (2): Last reviewed commit: ["build(deps): bump charm.land/bubbletea/v..."](https://github.com/mexirica/aptui/commit/385c028219b247ecdba675a89411022ff6d29d88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33919846)</sub>

<!-- /greptile_comment -->