### PR TITLE
fix: add detailCache for version-specific package details

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -101,8 +101,9 @@ type App struct {
 	ppaAdding bool
 	ppaInput  textinput.Model
 
-	infoCache map[string]apt.PackageInfo
-	pkgIndex  map[string]int
+	infoCache   map[string]apt.PackageInfo
+	detailCache map[string]apt.PackageInfo
+	pkgIndex    map[string]int
 
 	autoremovable    []string
 	autoremovableSet map[string]bool
@@ -226,6 +227,7 @@ func New() App {
 		upgradableMap:     make(map[string]model.Package),
 		selected:          make(map[string]bool),
 		infoCache:         make(map[string]apt.PackageInfo),
+		detailCache:       make(map[string]apt.PackageInfo),
 		pkgIndex:          make(map[string]int),
 		autoremovableSet:  make(map[string]bool),
 		heldSet:           make(map[string]bool),

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -36,6 +36,9 @@ func TestNewApp(t *testing.T) {
 	if a.infoCache == nil {
 		t.Error("infoCache should be initialized")
 	}
+	if a.detailCache == nil {
+		t.Error("detailCache should be initialized")
+	}
 	if !a.loading {
 		t.Error("app should start in loading state")
 	}
@@ -2150,6 +2153,27 @@ func TestOnPackageDetailLoaded_Success(t *testing.T) {
 	}
 	if _, ok := app.infoCache["vim"]; !ok {
 		t.Error("infoCache should contain vim")
+	}
+}
+
+func TestOnPackageDetailLoaded_VersionSpecific(t *testing.T) {
+	a := newTestApp()
+	a.infoCache = map[string]apt.PackageInfo{}
+	a.detailCache = map[string]apt.PackageInfo{}
+	a.filtered = []model.Package{{Name: "vim", Version: "8.2"}}
+	a.allPackages = []model.Package{{Name: "vim", Version: "8.2"}}
+	a.rebuildIndex()
+
+	info := "Package: vim\nVersion: 8.2\nInstalled-Size: 3000\nSection: editors\nArchitecture: amd64\nDescription: Vi IMproved"
+	msg := detailLoadedMsg{name: "vim", version: "8.2", info: info}
+	m, _ := a.onPackageDetailLoaded(msg)
+	app := m.(App)
+
+	if _, ok := app.infoCache["vim"]; ok {
+		t.Error("version-specific detail should not pollute infoCache")
+	}
+	if _, ok := app.detailCache["vim=8.2"]; !ok {
+		t.Error("detailCache should contain vim=8.2")
 	}
 }
 

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -107,7 +107,7 @@ func searchPackagesCmd(query string) tea.Cmd {
 func showPackageDetailCmd(name string, version string) tea.Cmd {
 	return func() tea.Msg {
 		info, err := apt.ShowPackage(name, version)
-		return detailLoadedMsg{name, info, err}
+		return detailLoadedMsg{name: name, version: version, info: info, err: err}
 	}
 }
 

--- a/internal/app/messages.go
+++ b/internal/app/messages.go
@@ -21,9 +21,10 @@ type searchResultMsg struct {
 }
 
 type detailLoadedMsg struct {
-	name string
-	info string
-	err  error
+	name    string
+	version string
+	info    string
+	err     error
 }
 
 type execFinishedMsg struct {

--- a/internal/app/update.go
+++ b/internal/app/update.go
@@ -408,7 +408,15 @@ func (a App) onPackageDetailLoaded(msg detailLoadedMsg) (tea.Model, tea.Cmd) {
 			if existing, ok := a.infoCache[msg.name]; ok && len(existing.Origins) > 0 {
 				pi.Origins = existing.Origins
 			}
-			a.infoCache[msg.name] = pi
+			if msg.version != "" {
+				// Version-specific lookup: store in detailCache to avoid
+				// overwriting infoCache with data that is specific to one
+				// version of the package.
+				cacheKey := msg.name + "=" + msg.version
+				a.detailCache[cacheKey] = pi
+			} else {
+				a.infoCache[msg.name] = pi
+			}
 			if pi.Essential {
 				a.essentialSet[msg.name] = true
 			}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the package-detail caching mechanism by introducing `detailRawCache` (a `map[string]string`) to store the raw `apt show` output alongside the parsed `PackageInfo` in `detailCache`. Cache keys are migrated from the `name\x00version` sentinel format to the cleaner `name=version` form.

- `updateSelectionCmd` now serves cached detail from `detailRawCache` directly, bypassing the subprocess entirely on repeat visits to a version-pinned package. The file-list reset block is correctly placed outside the cache-hit path so the panel is always refreshed.
- `onPackageDetailLoaded` skips `ParseShowEntry` when the entry is already in `detailCache`, preventing the double-`formatSize` corruption that corrupted `Size` on repeated cache hits, and uses the full raw string for `detailInfo` so the detail panel retains all fields (Maintainer, Depends, etc.).
- New tests cover raw-cache initialization, version-specific cache isolation from `infoCache`, size-formatting correctness across cache hits, and file-list refresh behavior.

<h3>Confidence Score: 5/5</h3>

- The change is safe to merge — it targets isolated caching paths, adds no new external calls, and is covered by focused regression tests for each fix.
- All three previously flagged defects (write-only cache, stale file-list panel on cache hit, double-`formatSize` corruption) are correctly addressed. The new `detailRawCache` ensures the full raw output is stored and reused without re-parsing, and the restructured `updateSelectionCmd` reaches the file-list reset block unconditionally. No new logic errors were found in the changed paths.
- No files require special attention.

<sub>Reviews (6): Last reviewed commit: ["Fix: add detailRawCache to enhance packa..."](https://github.com/mexirica/aptui/commit/7dfdb7c1c27f4b598f98596d0488d37e091b7167) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40493225)</sub>

<!-- /greptile_comment -->