### PR TITLE
Fix: restore working star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ export APTUI_THEME=light
 
 ---
 
-<a href="https://www.star-history.com/?repos=mexirica%2Faptui&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#mexirica/aptui&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=mexirica/aptui&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=mexirica/aptui&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=mexirica/aptui&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mexirica/aptui&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mexirica/aptui&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mexirica/aptui&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders. This change points the chart to a working service so the project's star history is visible again.

No behavior changes otherwise, only the chart link and image URLs in README.md were updated.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores the README’s star-history chart by moving its click-through and light, dark, and fallback image URLs to the working `star-history.dera.page` service.

- Replaces the chart’s external link.
- Updates all image variants to the replacement service’s SVG endpoint.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the README-only URL replacement is internally consistent and introduces no actionable issue.

The updated anchor and all three image variants use the replacement service’s expected URL forms while preserving the existing chart configuration.

<sub>Reviews (1): Last reviewed commit: ["Fix: restore working star history chart ..."](https://github.com/mexirica/aptui/commit/02df21256cdd2a9e9c642f5064574e6378896282) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54738131)</sub>

<!-- /greptile_comment -->